### PR TITLE
readIncrementally buffer overflow panic and infinite loop

### DIFF
--- a/rtuclient.go
+++ b/rtuclient.go
@@ -205,6 +205,11 @@ func readIncrementally(slaveID, functionCode byte, r io.Reader) ([]byte, error) 
 		case stateReadLength:
 			// read length byte
 			length = buf[0]
+			// max length = rtuMaxSize - SlaveID(1) - FunctionCode(1) - length(1) - CRC(2)
+			if length >= rtuMaxSize-5 {
+				return nil, fmt.Errorf("invalid length received: %d", length)
+			}
+
 			toRead = length
 			data[n] = length
 			n++

--- a/rtuclient_test.go
+++ b/rtuclient_test.go
@@ -7,6 +7,7 @@ package modbus
 import (
 	"bytes"
 	"testing"
+	"time"
 )
 
 func TestRTUEncoding(t *testing.T) {
@@ -235,7 +236,7 @@ func Test_readIncrementally(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
-			got, err := readIncrementally(tc.slaveID, tc.functionCode, bytes.NewBuffer(tc.data))
+			got, err := readIncrementally(tc.slaveID, tc.functionCode, bytes.NewBuffer(tc.data), time.Now().Add(time.Second*5))
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error but did not get one")


### PR DESCRIPTION
Not sure if you are accepting pull requests on this fork but it looked like you had some useful enhancements so I thought it was worth sending this.

1. readIncrementally could cause a panic due to an overflow in the buffer 'data'. This would only happen where a large value was received for 'length' and then sufficient data was sent through to oveflow the buffer (I had this occur when testing a device with dodgy cabling).

2. It was possible that readIncrementally would never exit. This would occur if the serial line delivered data continuously without ever delivering what was expected. Again this happened to me when testing with dodgy cabling (not the end of the world but made debugging confusing).