### PR TITLE
feat(rtu): detach serial port form activity tracking

### DIFF
--- a/rtuactivity.go
+++ b/rtuactivity.go
@@ -1,0 +1,82 @@
+package modbus
+
+import (
+	"sync"
+	"time"
+
+	"github.com/grid-x/serial"
+)
+
+type rtuActivityTracker struct {
+	// Serial port configuration.
+	serial.Config
+
+	Logger      logger
+	IdleTimeout time.Duration
+
+	lastActivity time.Time
+	closeTimer   *time.Timer
+
+	mu sync.Mutex
+
+	// port is platform-dependent data structure for serial port.
+	// rw lock
+	Port
+}
+
+func (mb *rtuActivityTracker) logf(format string, v ...interface{}) {
+	if mb.Logger != nil {
+		mb.Logger.Printf(format, v...)
+	}
+}
+
+func (mb *rtuActivityTracker) startCloseTimer() {
+	if mb.IdleTimeout <= 0 {
+		return
+	}
+	if mb.closeTimer == nil {
+		mb.closeTimer = time.AfterFunc(mb.IdleTimeout, mb.closeIdle)
+	} else {
+		mb.closeTimer.Reset(mb.IdleTimeout)
+	}
+}
+
+// closeIdle closes the connection if last activity is passed behind IdleTimeout.
+func (mb *rtuActivityTracker) closeIdle() {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	if mb.IdleTimeout <= 0 {
+		return
+	}
+	idle := time.Now().Sub(mb.lastActivity)
+	if idle >= mb.IdleTimeout {
+		mb.logf("modbus: closing connection due to idle timeout: %v", idle)
+		mb.Port.Close()
+	}
+}
+
+func (mb *rtuActivityTracker) Close() (err error) {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	err = mb.Port.Close()
+	mb.Port = nil
+	return
+}
+
+func (mb *rtuActivityTracker) Connect() (err error) {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	return mb.connect()
+}
+
+func (mb *rtuActivityTracker) connect() (err error) {
+	if mb.Port == nil {
+		port, err := serial.Open(&mb.Config)
+		if err != nil {
+			return err
+		}
+		mb.Port = &serialPort{ReadWriteCloser: port}
+	}
+	return
+}

--- a/serial.go
+++ b/serial.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"sync"
 	"time"
-
-	"github.com/grid-x/serial"
 )
 
 const (
@@ -20,82 +18,7 @@ const (
 
 // serialPort has configuration and I/O controller.
 type serialPort struct {
-	// Serial port configuration.
-	serial.Config
-
-	Logger      logger
-	IdleTimeout time.Duration
-
-	mu sync.Mutex
+	sync.Mutex
 	// port is platform-dependent data structure for serial port.
-	port         io.ReadWriteCloser
-	lastActivity time.Time
-	closeTimer   *time.Timer
-}
-
-func (mb *serialPort) Connect() (err error) {
-	mb.mu.Lock()
-	defer mb.mu.Unlock()
-
-	return mb.connect()
-}
-
-// connect connects to the serial port if it is not connected. Caller must hold the mutex.
-func (mb *serialPort) connect() error {
-	if mb.port == nil {
-		port, err := serial.Open(&mb.Config)
-		if err != nil {
-			return err
-		}
-		mb.port = port
-	}
-	return nil
-}
-
-func (mb *serialPort) Close() (err error) {
-	mb.mu.Lock()
-	defer mb.mu.Unlock()
-
-	return mb.close()
-}
-
-// close closes the serial port if it is connected. Caller must hold the mutex.
-func (mb *serialPort) close() (err error) {
-	if mb.port != nil {
-		err = mb.port.Close()
-		mb.port = nil
-	}
-	return
-}
-
-func (mb *serialPort) logf(format string, v ...interface{}) {
-	if mb.Logger != nil {
-		mb.Logger.Printf(format, v...)
-	}
-}
-
-func (mb *serialPort) startCloseTimer() {
-	if mb.IdleTimeout <= 0 {
-		return
-	}
-	if mb.closeTimer == nil {
-		mb.closeTimer = time.AfterFunc(mb.IdleTimeout, mb.closeIdle)
-	} else {
-		mb.closeTimer.Reset(mb.IdleTimeout)
-	}
-}
-
-// closeIdle closes the connection if last activity is passed behind IdleTimeout.
-func (mb *serialPort) closeIdle() {
-	mb.mu.Lock()
-	defer mb.mu.Unlock()
-
-	if mb.IdleTimeout <= 0 {
-		return
-	}
-	idle := time.Now().Sub(mb.lastActivity)
-	if idle >= mb.IdleTimeout {
-		mb.logf("modbus: closing connection due to idle timeout: %v", idle)
-		mb.close()
-	}
+	io.ReadWriteCloser
 }

--- a/serial_test.go
+++ b/serial_test.go
@@ -3,11 +3,13 @@ package modbus
 import (
 	"bytes"
 	"io"
+	"sync"
 	"testing"
 	"time"
 )
 
 type nopCloser struct {
+	sync.Mutex
 	io.ReadWriter
 
 	closed bool
@@ -22,15 +24,15 @@ func TestSerialCloseIdle(t *testing.T) {
 	port := &nopCloser{
 		ReadWriter: &bytes.Buffer{},
 	}
-	s := serialPort{
-		port:        port,
+	s := rtuActivityTracker{
+		Port:        port,
 		IdleTimeout: 100 * time.Millisecond,
 	}
 	s.lastActivity = time.Now()
 	s.startCloseTimer()
 
 	time.Sleep(150 * time.Millisecond)
-	if !port.closed || s.port != nil {
+	if !port.closed && s.Port == nil {
 		t.Fatalf("serial port is not closed when inactivity: %+v", port)
 	}
 }


### PR DESCRIPTION
Until now the serial port has taken over many tasks. It was responsible for
timeouts, new connections and closeing the connection. This makes the port quite
difficult to replace. Now the port has been replaced by an interface.
The activity tracking is done on a upper level.

Signed-off-by: Benedikt Bongartz <b.bongartz@gridx.de>