### PR TITLE
Expose the serial port's logger for RTU connections

### DIFF
--- a/asciiclient.go
+++ b/asciiclient.go
@@ -34,6 +34,7 @@ func NewASCIIClientHandler(address string) *ASCIIClientHandler {
 	handler.Address = address
 	handler.Timeout = serialTimeout
 	handler.IdleTimeout = serialIdleTimeout
+	handler.serialPort.Logger = handler // expose the logger
 	return handler
 }
 
@@ -165,6 +166,13 @@ func (mb *asciiPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 // asciiSerialTransporter implements Transporter interface.
 type asciiSerialTransporter struct {
 	serialPort
+	Logger logger
+}
+
+func (mb *asciiSerialTransporter) Printf(format string, v ...interface{}) {
+	if mb.Logger != nil {
+		mb.Logger.Printf(format, v...)
+	}
 }
 
 func (mb *asciiSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -54,6 +54,7 @@ func NewRTUClientHandler(address string) *RTUClientHandler {
 	handler.Address = address
 	handler.Timeout = serialTimeout
 	handler.IdleTimeout = serialIdleTimeout
+	handler.serialPort.Logger = handler // expose the logger
 	return handler
 }
 
@@ -137,6 +138,13 @@ func (mb *rtuPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 // rtuSerialTransporter implements Transporter interface.
 type rtuSerialTransporter struct {
 	serialPort
+	Logger logger
+}
+
+func (mb *rtuSerialTransporter) Printf(format string, v ...interface{}) {
+	if mb.Logger != nil {
+		mb.Logger.Printf(format, v...)
+	}
 }
 
 // InvalidLengthError is returned by readIncrementally when the modbus response would overflow buffer


### PR DESCRIPTION
While the `tcpclient`'s `tcpTransporter` exposes a logger, the `rtuclient`'s `rtuSerialTransporter` embeds a private `serialPort` which has a logger but isn't externally accessible. This PR exposes the serial ports logger through the handler similar to the `tcpTransporter`.