### PR TITLE
Bug fix: connection stuck forever with mismatched transaction ID

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -155,6 +155,19 @@ func (mb *tcpTransporter) Send(aduRequest []byte) (aduResponse []byte, err error
 			return
 		}
 
+
+		/*
+		 * If an answer to a previously timed-out request is already in teh buffer, this will result
+		 * in a transaction ID mismatch from which we will never recover.  To prevent this, just
+		 * flush any previous reponses before launching the next poll.  That's throwing away
+		 * possibly useful data, but the previous request was already satisfied with a timeout
+		 * error so that probably makes the most sense here.
+		 *
+		 * Be aware that this call resets the read deadline.
+		 */
+		mb.flushAll()
+
+
 		// Set timer to close when idle
 		mb.lastActivity = time.Now()
 		mb.startCloseTimer()
@@ -330,5 +343,32 @@ func (mb *tcpTransporter) closeIdle() {
 	if idle >= mb.IdleTimeout {
 		mb.logf("modbus: closing connection due to idle timeout: %v", idle)
 		mb.close()
+	}
+}
+
+
+/**
+ * This function implements a non-blocking read flush.  Be warned it resets
+ * the read deadline.
+ */
+func (mb *tcpTransporter) flushAll() (int, error) {
+	if err := mb.conn.SetReadDeadline(time.Now()); err != nil {
+		return 0, err
+	}
+
+	count := 0
+	buffer := make([]byte, 1024)
+
+	for {
+		n, err := mb.conn.Read(buffer)
+
+		if err != nil {
+			return count + n, err
+		} else if n > 0 {
+			count = count + n
+		} else {
+			/* didn't flush any new bytes, return */
+			return count, err
+		}
 	}
 }


### PR DESCRIPTION
connection) you might go to send the next poll and immediately receive
the previous response.  The result is a mismatch in the transaction ID
from which the connection will never recover.  There are a few ways to
mitigate this, including receiving the response in a loop, but since
this modbus tcp implementation is completely synchronous the simplest
thing to do is to simply flush the receive buffer immediately prior to
sending the next poll.