### PR TITLE
feat(cmd/modbus-cli): support writing single coil

### DIFF
--- a/cmd/modbus-cli/main.go
+++ b/cmd/modbus-cli/main.go
@@ -134,6 +134,20 @@ func exec(
 	switch fnCode {
 	case 0x01:
 		result, err = client.ReadCoils(uint16(register), uint16(quantity))
+	case 0x05:
+		const (
+			coilOn  uint16 = 0xFF00
+			coilOff uint16 = 0x0000
+		)
+		v := uint16(wval)
+		if v != coilOn && v != coilOff {
+			err = fmt.Errorf(
+				"illegal: expect %X to request the output to be on or %X to be off, got: %X",
+				coilOn, coilOff, v,
+			)
+			return
+		}
+		result, err = client.WriteSingleCoil(uint16(register), v)
 	case 0x06:
 		max := float64(math.MaxUint16)
 		if wval > max || wval < 0 {

--- a/cmd/modbus-cli/main.go
+++ b/cmd/modbus-cli/main.go
@@ -139,13 +139,9 @@ func exec(
 			coilOn  uint16 = 0xFF00
 			coilOff uint16 = 0x0000
 		)
-		v := uint16(wval)
-		if v != coilOn && v != coilOff {
-			err = fmt.Errorf(
-				"illegal: expect %X to request the output to be on or %X to be off, got: %X",
-				coilOn, coilOff, v,
-			)
-			return
+		v := coilOff
+		if wval > 0 {
+			v = coilOn
 		}
 		result, err = client.WriteSingleCoil(uint16(register), v)
 	case 0x06:


### PR DESCRIPTION
With this pr the modbus-cli tool is extended by the function `0x05`. This allows to switch individual outputs on and off.

Usage:
```bash
# read
modbus-cli -slaveID=0xFF -address=tcp://127.0.0.1:502 -fn-code=0x01 -type-parse=uint8 -register=54321 -quantity=1 -log-frame

# Turn on
modbus-cli -slaveID=0xFF -address=tcp://127.0.0.1:502 -fn-code=0x05 -type-parse=uint8 -register=54321 -quantity=1 -log-frame -write-value=0xFF00

# Turn off
modbus-cli -slaveID=0xFF -address=tcp://127.0.0.1:502 -fn-code=0x05 -type-parse=uint8 -register=54321 -quantity=1 -log-frame -write-value=0x0000
```

Ref:
https://ozeki.hu/p_5880-mobdbus-function-code-5-write-single-coil.html

Signed-off-by: Benedikt Bongartz benne@klimlive.de