### PR TITLE
Add connect delay

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -131,6 +131,8 @@ type tcpTransporter struct {
 	LinkRecoveryTimeout time.Duration
 	// Recovery timeout if the protocol is malformed, e.g. wrong transaction ID
 	ProtocolRecoveryTimeout time.Duration
+	// Silent period after successful connection
+	ConnectDelay time.Duration
 	// Transmission logger
 	Logger logger
 
@@ -273,6 +275,9 @@ func (mb *tcpTransporter) connect() error {
 			return err
 		}
 		mb.conn = conn
+
+		// silent period
+		time.Sleep(mb.ConnectDelay)
 	}
 	return nil
 }


### PR DESCRIPTION
Some modbus devices from Huawei need a quiet period after initial connection. Since the connect is handled inside the library, the delay can only be added here. If clearer, we could also name this `SilentDelay`. The scope of the changes is minimal, no logic is impacted.