### PR TITLE
Validate result length againt request

### DIFF
--- a/client.go
+++ b/client.go
@@ -125,6 +125,10 @@ func (mb *client) ReadHoldingRegisters(address, quantity uint16) (results []byte
 		err = fmt.Errorf("modbus: response data size '%v' does not match count '%v'", length, count)
 		return
 	}
+	if count != 2*int(quantity) {
+		err = fmt.Errorf("modbus: response data size '%v' does not match request quantity '%v'", length, quantity)
+		return
+	}
 	results = response.Data[1:]
 	return
 }
@@ -154,6 +158,10 @@ func (mb *client) ReadInputRegisters(address, quantity uint16) (results []byte, 
 	length := len(response.Data) - 1
 	if count != length {
 		err = fmt.Errorf("modbus: response data size '%v' does not match count '%v'", length, count)
+		return
+	}
+	if count != 2*int(quantity) {
+		err = fmt.Errorf("modbus: response data size '%v' does not match request quantity '%v'", length, quantity)
 		return
 	}
 	results = response.Data[1:]


### PR DESCRIPTION
In https://github.com/evcc-io/evcc/discussions/3222 we've observed the infamous Huawei inverter return less bytes than requested as "success". Subsequently that leads to downstream `panic` when using the `binary.BigEndian` decoding functions.

Instead, I'd suggest to validate proper length in the library. Same could/should be added for coils/ discrete inputs.