### PR TITLE
Expose packager and transporter structs for use with NewClient2

### DIFF
--- a/ascii_over_tcp_client.go
+++ b/ascii_over_tcp_client.go
@@ -10,16 +10,16 @@ import (
 
 // ASCIIOverTCPClientHandler implements Packager and Transporter interface.
 type ASCIIOverTCPClientHandler struct {
-	asciiPackager
-	asciiTCPTransporter
+	ASCIIPackager
+	ASCIITCPTransporter
 }
 
 // NewASCIIOverTCPClientHandler allocates and initializes a ASCIIOverTCPClientHandler.
 func NewASCIIOverTCPClientHandler(address string) *ASCIIOverTCPClientHandler {
-	handler := &ASCIIOverTCPClientHandler{}
-	handler.Address = address
-	handler.Timeout = tcpTimeout
-	handler.IdleTimeout = tcpIdleTimeout
+	handler := &ASCIIOverTCPClientHandler{
+		ASCIIPackager:       ASCIIPackager{},
+		ASCIITCPTransporter: NewASCIITCPTransporter(address),
+	}
 	return handler
 }
 
@@ -29,12 +29,22 @@ func ASCIIOverTCPClient(address string) Client {
 	return NewClient(handler)
 }
 
-// asciiTCPTransporter implements Transporter interface.
-type asciiTCPTransporter struct {
-	tcpTransporter
+var _ Transporter = (*ASCIITCPTransporter)(nil)
+
+// ASCIITCPTransporter implements Transporter interface.
+type ASCIITCPTransporter struct {
+	TCPTransporter
 }
 
-func (mb *asciiTCPTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
+// NewASCIITCPTransporter creates ASCIITCPTransporter with default values
+func NewASCIITCPTransporter(address string) ASCIITCPTransporter {
+	return ASCIITCPTransporter{
+		TCPTransporter: NewTCPTransporter(address),
+	}
+}
+
+// Send sends data to server and ensures response has required length.
+func (mb *ASCIITCPTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 

--- a/asciiclient.go
+++ b/asciiclient.go
@@ -166,7 +166,6 @@ func (mb *ASCIIPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 // ASCIISerialTransporter implements Transporter interface.
 type ASCIISerialTransporter struct {
 	SerialPort
-	Logger logger
 }
 
 // NewASCIISerialTransporter creates ASCIISerialTransporter with default values
@@ -174,8 +173,15 @@ func NewASCIISerialTransporter(address string) ASCIISerialTransporter {
 	t := ASCIISerialTransporter{
 		SerialPort: *NewSerialPort(address),
 	}
-	t.SerialPort.Logger = t.Logger
+	t.SerialPort.Logger = &t
 	return t
+}
+
+// Printf implements the Logger interface
+func (mb *ASCIISerialTransporter) Printf(format string, v ...interface{}) {
+	if mb.Logger != nil {
+		mb.Logger.Printf(format, v...)
+	}
 }
 
 // Send sends data to serial device and ensures adequate response for request type

--- a/asciiclient_test.go
+++ b/asciiclient_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestASCIIEncoding(t *testing.T) {
-	encoder := asciiPackager{}
+	encoder := ASCIIPackager{}
 	encoder.SlaveID = 17
 
 	pdu := ProtocolDataUnit{}
@@ -28,7 +28,7 @@ func TestASCIIEncoding(t *testing.T) {
 }
 
 func TestASCIIDecoding(t *testing.T) {
-	decoder := asciiPackager{}
+	decoder := ASCIIPackager{}
 	decoder.SlaveID = 247
 	adu := []byte(":F7031389000A60\r\n")
 
@@ -47,7 +47,7 @@ func TestASCIIDecoding(t *testing.T) {
 }
 
 func TestASCIIDecodeStartCharacter(t *testing.T) {
-	decoder := asciiPackager{}
+	decoder := ASCIIPackager{}
 	aduReq := []byte(":010300010002F9\r\n")
 	aduRespGreaterThan := []byte(">010304010F1509CA\r\n")
 	aduRespColon := []byte(":010304010F1509CA\r\n")
@@ -69,7 +69,7 @@ func TestASCIIDecodeStartCharacter(t *testing.T) {
 }
 
 func BenchmarkASCIIEncoder(b *testing.B) {
-	encoder := asciiPackager{
+	encoder := ASCIIPackager{
 		SlaveID: 10,
 	}
 	pdu := ProtocolDataUnit{
@@ -85,7 +85,7 @@ func BenchmarkASCIIEncoder(b *testing.B) {
 }
 
 func BenchmarkASCIIDecoder(b *testing.B) {
-	decoder := asciiPackager{
+	decoder := ASCIIPackager{
 		SlaveID: 10,
 	}
 	adu := []byte(":F7031389000A60\r\n")

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,35 @@
+package modbus
+
+import "testing"
+
+const localhost = ":502"
+
+func TestTcp(t *testing.T) {
+	pack := TCPPackager{SlaveID: 1}
+	trans := NewTCPTransporter(localhost)
+	_ = NewClient2(&pack, &trans)
+}
+
+func TestRtuOverTcp(t *testing.T) {
+	pack := RtuPackager{SlaveID: 1}
+	trans := NewRTUTCPTransporter(localhost)
+	_ = NewClient2(&pack, &trans)
+}
+
+func TestAsciiOverTcp(t *testing.T) {
+	pack := ASCIIPackager{SlaveID: 1}
+	trans := NewASCIITCPTransporter(localhost)
+	_ = NewClient2(&pack, &trans)
+}
+
+func TestRtu(t *testing.T) {
+	pack := RtuPackager{SlaveID: 1}
+	trans := NewRtuSerialTransporter(localhost)
+	_ = NewClient2(&pack, &trans)
+}
+
+func TestAscii(t *testing.T) {
+	pack := ASCIIPackager{SlaveID: 1}
+	trans := NewASCIISerialTransporter(localhost)
+	_ = NewClient2(&pack, &trans)
+}

--- a/rtu_over_tcp_client.go
+++ b/rtu_over_tcp_client.go
@@ -11,16 +11,15 @@ import (
 
 // RTUOverTCPClientHandler implements Packager and Transporter interface.
 type RTUOverTCPClientHandler struct {
-	rtuPackager
-	rtuTCPTransporter
+	RtuPackager
+	RtuTCPTransporter
 }
 
 // NewRTUOverTCPClientHandler allocates and initializes a RTUOverTCPClientHandler.
 func NewRTUOverTCPClientHandler(address string) *RTUOverTCPClientHandler {
-	handler := &RTUOverTCPClientHandler{}
-	handler.Address = address
-	handler.Timeout = tcpTimeout
-	handler.IdleTimeout = tcpIdleTimeout
+	handler := &RTUOverTCPClientHandler{
+		RtuTCPTransporter: NewRTUTCPTransporter(address),
+	}
 	return handler
 }
 
@@ -30,13 +29,22 @@ func RTUOverTCPClient(address string) Client {
 	return NewClient(handler)
 }
 
-// rtuTCPTransporter implements Transporter interface.
-type rtuTCPTransporter struct {
-	tcpTransporter
+var _ Transporter = (*RtuTCPTransporter)(nil)
+
+// RtuTCPTransporter implements Transporter interface.
+type RtuTCPTransporter struct {
+	TCPTransporter
+}
+
+// NewRTUTCPTransporter creates RtuTCPTransporter with default values
+func NewRTUTCPTransporter(address string) RtuTCPTransporter {
+	return RtuTCPTransporter{
+		TCPTransporter: NewTCPTransporter(address),
+	}
 }
 
 // Send sends data to server and ensures adequate response for request type
-func (mb *rtuTCPTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
+func (mb *RtuTCPTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -138,7 +138,6 @@ func (mb *RtuPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 // RtuSerialTransporter implements Transporter interface.
 type RtuSerialTransporter struct {
 	SerialPort
-	Logger logger
 }
 
 var _ Transporter = (*RtuSerialTransporter)(nil)
@@ -148,8 +147,15 @@ func NewRtuSerialTransporter(address string) RtuSerialTransporter {
 	t := RtuSerialTransporter{
 		SerialPort: *NewSerialPort(address),
 	}
-	t.SerialPort.Logger = t.Logger
+	t.SerialPort.Logger = &t
 	return t
+}
+
+// Printf implements the Logger interface
+func (mb *RtuSerialTransporter) Printf(format string, v ...interface{}) {
+	if mb.Logger != nil {
+		mb.Logger.Printf(format, v...)
+	}
 }
 
 // InvalidLengthError is returned by readIncrementally when the modbus response would overflow buffer

--- a/rtuclient_prop_test.go
+++ b/rtuclient_prop_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRTUEncodeDecode(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		packager := &rtuPackager{
+		packager := &RtuPackager{
 			SlaveID: rapid.Byte().Draw(t, "SlaveID").(byte),
 		}
 

--- a/rtuclient_test.go
+++ b/rtuclient_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRTUEncoding(t *testing.T) {
-	encoder := rtuPackager{}
+	encoder := RtuPackager{}
 	encoder.SlaveID = 0x01
 
 	pdu := ProtocolDataUnit{}
@@ -30,7 +30,7 @@ func TestRTUEncoding(t *testing.T) {
 }
 
 func TestRTUDecoding(t *testing.T) {
-	decoder := rtuPackager{}
+	decoder := RtuPackager{}
 	adu := []byte{0x01, 0x10, 0x8A, 0x00, 0x00, 0x03, 0xAA, 0x10}
 
 	pdu, err := decoder.Decode(adu)
@@ -71,7 +71,7 @@ func TestCalculateResponseLength(t *testing.T) {
 }
 
 func BenchmarkRTUEncoder(b *testing.B) {
-	encoder := rtuPackager{
+	encoder := RtuPackager{
 		SlaveID: 10,
 	}
 	pdu := ProtocolDataUnit{
@@ -87,7 +87,7 @@ func BenchmarkRTUEncoder(b *testing.B) {
 }
 
 func BenchmarkRTUDecoder(b *testing.B) {
-	decoder := rtuPackager{
+	decoder := RtuPackager{
 		SlaveID: 10,
 	}
 	adu := []byte{0x01, 0x10, 0x8A, 0x00, 0x00, 0x03, 0xAA, 0x10}

--- a/serial_test.go
+++ b/serial_test.go
@@ -22,7 +22,7 @@ func TestSerialCloseIdle(t *testing.T) {
 	port := &nopCloser{
 		ReadWriter: &bytes.Buffer{},
 	}
-	s := serialPort{
+	s := SerialPort{
 		port:        port,
 		IdleTimeout: 100 * time.Millisecond,
 	}

--- a/tcpclient_prop_test.go
+++ b/tcpclient_prop_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestTCPEncodeDecode(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		packager := &tcpPackager{
+		packager := &TCPPackager{
 			transactionID: rapid.Uint32().Draw(t, "transactionID").(uint32),
 			SlaveID:       rapid.Byte().Draw(t, "SlaveID").(byte),
 		}

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTCPEncoding(t *testing.T) {
-	packager := tcpPackager{}
+	packager := TCPPackager{}
 	pdu := ProtocolDataUnit{}
 	pdu.FunctionCode = 3
 	pdu.Data = []byte{0, 4, 0, 3}
@@ -30,7 +30,7 @@ func TestTCPEncoding(t *testing.T) {
 }
 
 func TestTCPDecoding(t *testing.T) {
-	packager := tcpPackager{}
+	packager := TCPPackager{}
 	packager.transactionID = 1
 	packager.SlaveID = 17
 	adu := []byte{0, 1, 0, 0, 0, 6, 17, 3, 0, 120, 0, 3}
@@ -69,7 +69,7 @@ func TestTCPTransporter(t *testing.T) {
 			return
 		}
 	}()
-	client := &tcpTransporter{
+	client := &TCPTransporter{
 		Address:     ln.Addr().String(),
 		Timeout:     1 * time.Second,
 		IdleTimeout: 100 * time.Millisecond,
@@ -112,7 +112,7 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 		defer conn.Close()
 		// ensure that answer is only written after second read attempt failed
 		time.Sleep(2500 * time.Millisecond)
-		packager := &tcpPackager{SlaveID: 0}
+		packager := &TCPPackager{SlaveID: 0}
 		pdu := &ProtocolDataUnit{
 			FunctionCode: FuncCodeReadInputRegisters,
 			Data:         append([]byte{0x02}, data...),
@@ -173,7 +173,7 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 }
 
 func BenchmarkTCPEncoder(b *testing.B) {
-	encoder := tcpPackager{
+	encoder := TCPPackager{
 		SlaveID: 10,
 	}
 	pdu := ProtocolDataUnit{
@@ -189,7 +189,7 @@ func BenchmarkTCPEncoder(b *testing.B) {
 }
 
 func BenchmarkTCPDecoder(b *testing.B) {
-	decoder := tcpPackager{
+	decoder := TCPPackager{
 		SlaveID: 10,
 	}
 	adu := []byte{0, 1, 0, 0, 0, 6, 17, 3, 0, 120, 0, 3}


### PR DESCRIPTION
Fix https://github.com/grid-x/modbus/issues/56

This PR exposes packers and transporters. It does not modify existing api:

- make packager/transporter fields public members of client handlers
- add `New*Transporter` methods

Notes on implementation:

- Use of public fields in the exposed client requires exposing the package/transporter types. With private members, the types returned by the `New*Transporter` methods would be "annoying" for the linter.
- There is one open inconsistency with the current approach: while serial transports hide the serial port as implementation detail, the *TCP transports expose the underlying TCP transport. That can be changed, if desired consistently for both cases.
- exposing `TCPTransporter` (which is an implementation detail) as part of the `ASCII/RTUOverTCP` transporters is unfortunate but required to keep the public fields visible.
- serial transporters `Printf()` method was removed- it seems unused (will split into separete PR)

**TODO**

- [ ] pointer receiver for serial transport is necessary to avoid copying of lock in serial port
- [ ] consistently make all transports pointer receivers
- [ ] decide if same is desired for packagers
- [ ] decide future of rtu/ascii `Printf()` public api. With making `serialTransport` public, the transport's logger should be used instead. Proposal: remove `Printf()` (potential though minor BC break).

**Alternatives:**

Add a `Clone()` method that clones the entire client handler, sharing the underlying transport https://github.com/grid-x/modbus/pull/70.

Maybe think about something like:

```Go
// WithPackager returns a new TCPClientHandler with given packager.
func (h *TCPClientHandler) WithPackager(p TCPPackager) {
	h.TCPPackager = p
}
```