### PR TITLE
Fix Modbus-CLI for WriteMultipleRegisters

### DIFF
--- a/cmd/modbus-cli/main.go
+++ b/cmd/modbus-cli/main.go
@@ -173,7 +173,7 @@ func exec(
 			buf = make([]byte, 8)
 			w.PutFloat64(buf, float64(wval))
 		}
-		result, err = client.WriteMultipleRegisters(uint16(register), uint16(len(buf)), buf)
+		result, err = client.WriteMultipleRegisters(uint16(register), uint16(len(buf))/2, buf)
 	case 0x04:
 		result, err = client.ReadInputRegisters(uint16(register), uint16(quantity))
 	case 0x03:


### PR DESCRIPTION
During field tests, we were not able to successfully use function code 16 (0x10, WriteMultipleRegisters). It returns an Expcetion for Illegal Data Value.

When enabling logs with `log-frame`, we got:
```
modbus: send 00 01 00 00 00 09 01 10 00 00 00 02 02 00 00
modbus: recv 00 01 00 00 00 03 01 90 03
modbus: exception '3' (illegal data value), function '144'
```

If we look closer at the modbus frame that was sent, i.e. `10 00 00 00 02 02 00 00` and decode it following http://pps2.com/images/smf/MB_16_Write_Reg.jpg, we get:

```
10 << Function Code 16
00 00 
00 02 << 2 registers that should be written
02 << 2 bytes that are written
00 00 << data: 00 00
```

The number of bytes matches the number of registers which is the issue here. A register has 16 bit and thus, it must be half the length of bytes.

After fixing, we were able to successfully write registers using this function code.