### PR TITLE
Use embedded fields directly

### DIFF
--- a/asciiclient.go
+++ b/asciiclient.go
@@ -231,7 +231,7 @@ func writeHex(buf *bytes.Buffer, value []byte) (err error) {
 	return
 }
 
-// readHex decodes hexa string to byte, e.g. "8C" => 0x8C.
+// readHex decodes hex string to byte, e.g. "8C" => 0x8C.
 func readHex(data []byte) (value byte, err error) {
 	var dst [1]byte
 	if _, err = hex.Decode(dst[:], data[0:2]); err != nil {

--- a/asciiclient.go
+++ b/asciiclient.go
@@ -177,19 +177,19 @@ func (mb *asciiSerialTransporter) Printf(format string, v ...interface{}) {
 }
 
 func (mb *asciiSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
-	mb.serialPort.mu.Lock()
-	defer mb.serialPort.mu.Unlock()
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
 
 	// Make sure port is connected
-	if err = mb.serialPort.connect(); err != nil {
+	if err = mb.connect(); err != nil {
 		return
 	}
 	// Start the timer to close when idle
-	mb.serialPort.lastActivity = time.Now()
-	mb.serialPort.startCloseTimer()
+	mb.lastActivity = time.Now()
+	mb.startCloseTimer()
 
 	// Send the request
-	mb.serialPort.logf("modbus: send % x\n", aduRequest)
+	mb.logf("modbus: send % x\n", aduRequest)
 	if _, err = mb.port.Write(aduRequest); err != nil {
 		return
 	}
@@ -212,7 +212,7 @@ func (mb *asciiSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, e
 		}
 	}
 	aduResponse = data[:length]
-	mb.serialPort.logf("modbus: recv % x\n", aduResponse)
+	mb.logf("modbus: recv % x\n", aduResponse)
 	return
 }
 

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -161,12 +161,11 @@ func (e *InvalidLengthError) Error() string {
 
 // readIncrementally reads incrementally
 func readIncrementally(slaveID, functionCode byte, r io.Reader, deadline time.Time) ([]byte, error) {
-	n := 0
 	data := make([]byte, rtuMaxSize)
 
 	state := stateSlaveID
 	var length, toRead byte
-	crcCount := 0
+	var n, crcCount int
 
 	for {
 		if time.Now().After(deadline) { // Possible that serialport may spew data
@@ -255,7 +254,6 @@ func readIncrementally(slaveID, functionCode byte, r io.Reader, deadline time.Ti
 			}
 		}
 	}
-
 }
 
 func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
@@ -263,15 +261,15 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	defer mb.mu.Unlock()
 
 	// Make sure port is connected
-	if err = mb.serialPort.connect(); err != nil {
+	if err = mb.connect(); err != nil {
 		return
 	}
 	// Start the timer to close when idle
-	mb.serialPort.lastActivity = time.Now()
-	mb.serialPort.startCloseTimer()
+	mb.lastActivity = time.Now()
+	mb.startCloseTimer()
 
 	// Send the request
-	mb.serialPort.logf("modbus: send % x\n", aduRequest)
+	mb.logf("modbus: send % x\n", aduRequest)
 	if _, err = mb.port.Write(aduRequest); err != nil {
 		return
 	}
@@ -280,8 +278,8 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	bytesToRead := calculateResponseLength(aduRequest)
 	time.Sleep(mb.calculateDelay(len(aduRequest) + bytesToRead))
 
-	data, err := readIncrementally(aduRequest[0], aduRequest[1], mb.port, time.Now().Add(mb.serialPort.Config.Timeout))
-	mb.serialPort.logf("modbus: recv % x\n", data[:])
+	data, err := readIncrementally(aduRequest[0], aduRequest[1], mb.port, time.Now().Add(mb.Config.Timeout))
+	mb.logf("modbus: recv % x\n", data[:])
 	aduResponse = data
 	return
 }


### PR DESCRIPTION
This PR aligns and standardises the implementations of ASCII and RTU serial transporters. Before this PR, there was a mix of accessing embedded field's fields directly or via the embedded field. This PR consistently accesses them directly.

It also contains a minor optimisation for variable initialisation in `readIncrementally`.