### PR TITLE
Avoid named returns

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -68,14 +68,15 @@ func (mb *tcpPackager) SetSlave(slaveID byte) {
 }
 
 // Encode adds modbus application protocol header:
-//  Transaction identifier: 2 bytes
-//  Protocol identifier: 2 bytes
-//  Length: 2 bytes
-//  Unit identifier: 1 byte
-//  Function code: 1 byte
-//  Data: n bytes
-func (mb *tcpPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
-	adu = make([]byte, tcpHeaderSize+1+len(pdu.Data))
+//
+//	Transaction identifier: 2 bytes
+//	Protocol identifier: 2 bytes
+//	Length: 2 bytes
+//	Unit identifier: 1 byte
+//	Function code: 1 byte
+//	Data: n bytes
+func (mb *tcpPackager) Encode(pdu *ProtocolDataUnit) ([]byte, error) {
+	adu := make([]byte, tcpHeaderSize+1+len(pdu.Data))
 
 	// Transaction identifier
 	transactionID := atomic.AddUint32(&mb.transactionID, 1)
@@ -91,7 +92,7 @@ func (mb *tcpPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	// PDU
 	adu[tcpHeaderSize] = pdu.FunctionCode
 	copy(adu[tcpHeaderSize+1:], pdu.Data)
-	return
+	return adu, nil
 }
 
 // Verify confirms transaction, protocol and unit id.
@@ -100,23 +101,23 @@ func (mb *tcpPackager) Verify(aduRequest []byte, aduResponse []byte) error {
 }
 
 // Decode extracts PDU from TCP frame:
-//  Transaction identifier: 2 bytes
-//  Protocol identifier: 2 bytes
-//  Length: 2 bytes
-//  Unit identifier: 1 byte
-func (mb *tcpPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
+//
+//	Transaction identifier: 2 bytes
+//	Protocol identifier: 2 bytes
+//	Length: 2 bytes
+//	Unit identifier: 1 byte
+func (mb *tcpPackager) Decode(adu []byte) (*ProtocolDataUnit, error) {
 	// Read length value in the header
 	length := binary.BigEndian.Uint16(adu[4:])
 	pduLength := len(adu) - tcpHeaderSize
 	if pduLength <= 0 || pduLength != int(length-1) {
-		err = fmt.Errorf("modbus: length in response '%v' does not match pdu data length '%v'", length-1, pduLength)
-		return
+		return nil, fmt.Errorf("modbus: length in response '%v' does not match pdu data length '%v'", length-1, pduLength)
 	}
-	pdu = &ProtocolDataUnit{}
-	// The first byte after header is function code
-	pdu.FunctionCode = adu[tcpHeaderSize]
-	pdu.Data = adu[tcpHeaderSize+1:]
-	return
+	pdu := &ProtocolDataUnit{
+		FunctionCode: adu[tcpHeaderSize], // The first byte after header is function code
+		Data:         adu[tcpHeaderSize+1:],
+	}
+	return pdu, nil
 }
 
 // tcpTransporter implements Transporter interface.
@@ -156,7 +157,7 @@ const (
 )
 
 // Send sends data to server and ensures response length is greater than header length.
-func (mb *tcpTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
+func (mb *tcpTransporter) Send(aduRequest []byte) ([]byte, error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 
@@ -165,8 +166,8 @@ func (mb *tcpTransporter) Send(aduRequest []byte) (aduResponse []byte, err error
 
 	for {
 		// Establish a new connection if not connected
-		if err = mb.connect(); err != nil {
-			return
+		if err := mb.connect(); err != nil {
+			return nil, err
 		}
 
 		// Set timer to close when idle
@@ -177,24 +178,24 @@ func (mb *tcpTransporter) Send(aduRequest []byte) (aduResponse []byte, err error
 		if mb.Timeout > 0 {
 			timeout = mb.lastActivity.Add(mb.Timeout)
 		}
-		if err = mb.conn.SetDeadline(timeout); err != nil {
-			return
+		if err := mb.conn.SetDeadline(timeout); err != nil {
+			return nil, err
 		}
 		// Send data
 		mb.logf("modbus: send % x", aduRequest)
-		if _, err = mb.conn.Write(aduRequest); err != nil {
-			return
+		if _, err := mb.conn.Write(aduRequest); err != nil {
+			return nil, err
 		}
 
 		mb.lastAttemptedTransactionID = binary.BigEndian.Uint16(aduRequest)
 		var res readResult
-		aduResponse, res, err = mb.readResponse(aduRequest, data[:], recoveryDeadline)
+		aduResponse, res, err := mb.readResponse(aduRequest, data[:], recoveryDeadline)
 		switch res {
 		case readResultDone:
 			if err == nil {
 				mb.lastSuccessfulTransactionID = binary.BigEndian.Uint16(aduResponse)
 			}
-			return
+			return nil, err
 		case readResultRetry:
 			continue
 		}
@@ -262,26 +263,23 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 	}
 }
 
-func (mb *tcpTransporter) processResponse(data []byte) (aduResponse []byte, err error) {
+func (mb *tcpTransporter) processResponse(data []byte) ([]byte, error) {
 	// Read length, ignore transaction & protocol id (4 bytes)
 	length := int(binary.BigEndian.Uint16(data[4:]))
 	if length <= 0 {
 		mb.flush(data[:])
-		err = ErrTCPHeaderLength(length)
-		return
+		return nil, ErrTCPHeaderLength(length)
 	}
 	if length > (tcpMaxLength - (tcpHeaderSize - 1)) {
 		mb.flush(data[:])
-		err = ErrTCPHeaderLength(length)
-		return
+		return nil, ErrTCPHeaderLength(length)
 	}
 	// Skip unit id
 	length += tcpHeaderSize - 1
-	if _, err = io.ReadFull(mb.conn, data[tcpHeaderSize:length]); err != nil {
-		return
+	if _, err := io.ReadFull(mb.conn, data[tcpHeaderSize:length]); err != nil {
+		return nil, err
 	}
-	aduResponse = data[:length]
-	return
+	return data[:length], nil
 }
 
 type errTransactionIDMismatch struct {
@@ -292,27 +290,24 @@ func (e errTransactionIDMismatch) Error() string {
 	return fmt.Sprintf("modbus: response transaction id '%v' does not match request '%v'", e.got, e.expected)
 }
 
-func verify(aduRequest []byte, aduResponse []byte) (err error) {
+func verify(aduRequest []byte, aduResponse []byte) error {
 	// Transaction id
 	responseVal := binary.BigEndian.Uint16(aduResponse)
 	requestVal := binary.BigEndian.Uint16(aduRequest)
 	if responseVal != requestVal {
-		err = errTransactionIDMismatch{got: responseVal, expected: requestVal}
-		return
+		return errTransactionIDMismatch{got: responseVal, expected: requestVal}
 	}
 	// Protocol id
 	responseVal = binary.BigEndian.Uint16(aduResponse[2:])
 	requestVal = binary.BigEndian.Uint16(aduRequest[2:])
 	if responseVal != requestVal {
-		err = fmt.Errorf("modbus: response protocol id '%v' does not match request '%v'", responseVal, requestVal)
-		return
+		return fmt.Errorf("modbus: response protocol id '%v' does not match request '%v'", responseVal, requestVal)
 	}
 	// Unit id (1 byte)
 	if aduResponse[6] != aduRequest[6] {
-		err = fmt.Errorf("modbus: response unit id '%v' does not match request '%v'", aduResponse[6], aduRequest[6])
-		return
+		return fmt.Errorf("modbus: response unit id '%v' does not match request '%v'", aduResponse[6], aduRequest[6])
 	}
-	return
+	return nil
 }
 
 // Connect establishes a new connection to the address in Address.
@@ -360,18 +355,19 @@ func (mb *tcpTransporter) Close() error {
 
 // flush flushes pending data in the connection,
 // returns io.EOF if connection is closed.
-func (mb *tcpTransporter) flush(b []byte) (err error) {
-	if err = mb.conn.SetReadDeadline(time.Now()); err != nil {
-		return
+func (mb *tcpTransporter) flush(b []byte) error {
+	if err := mb.conn.SetReadDeadline(time.Now()); err != nil {
+		return err
 	}
 	// Timeout setting will be reset when reading
-	if _, err = mb.conn.Read(b); err != nil {
+	if _, err := mb.conn.Read(b); err != nil {
 		// Ignore timeout error
 		if netError, ok := err.(net.Error); ok && netError.Timeout() {
-			err = nil
+			return nil
 		}
+		return err
 	}
-	return
+	return nil
 }
 
 func (mb *tcpTransporter) logf(format string, v ...interface{}) {
@@ -381,12 +377,13 @@ func (mb *tcpTransporter) logf(format string, v ...interface{}) {
 }
 
 // closeLocked closes current connection. Caller must hold the mutex before calling this method.
-func (mb *tcpTransporter) close() (err error) {
+func (mb *tcpTransporter) close() error {
 	if mb.conn != nil {
-		err = mb.conn.Close()
+		err := mb.conn.Close()
 		mb.conn = nil
+		return err
 	}
-	return
+	return nil
 }
 
 // closeIdle closes the connection if last activity is passed behind IdleTimeout.


### PR DESCRIPTION
Afaikt idiomatic Go tries to avoid named returns where possible. It makes the code clearer and easier to read.

This PR updates the obvious methods, though not all.