### PR TITLE
Simplify lrc

### DIFF
--- a/asciiclient.go
+++ b/asciiclient.go
@@ -76,7 +76,7 @@ func (mb *asciiPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	}
 	// Exclude the beginning colon and terminating CRLF pair characters
 	var lrc lrc
-	lrc.pushByte(mb.SlaveID).pushByte(pdu.FunctionCode).pushBytes(pdu.Data)
+	lrc.push(mb.SlaveID).push(pdu.FunctionCode).push(pdu.Data...)
 	if err = writeHex(&buf, []byte{lrc.value()}); err != nil {
 		return
 	}
@@ -154,7 +154,7 @@ func (mb *asciiPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 	}
 	// Calculate checksum
 	var lrc lrc
-	lrc.pushByte(address).pushByte(pdu.FunctionCode).pushBytes(pdu.Data)
+	lrc.push(address).push(pdu.FunctionCode).push(pdu.Data...)
 	if lrcVal != lrc.value() {
 		err = fmt.Errorf("modbus: response lrc '%v' does not match expected '%v'", lrcVal, lrc.value())
 		return

--- a/asciiclient.go
+++ b/asciiclient.go
@@ -55,12 +55,13 @@ func (mb *asciiPackager) SetSlave(slaveID byte) {
 }
 
 // Encode encodes PDU in a ASCII frame:
-//  Start           : 1 char
-//  Address         : 2 chars
-//  Function        : 2 chars
-//  Data            : 0 up to 2x252 chars
-//  LRC             : 2 chars
-//  End             : 2 chars
+//
+//	Start           : 1 char
+//	Address         : 2 chars
+//	Function        : 2 chars
+//	Data            : 0 up to 2x252 chars
+//	LRC             : 2 chars
+//	End             : 2 chars
 func (mb *asciiPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	var buf bytes.Buffer
 
@@ -75,7 +76,6 @@ func (mb *asciiPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	}
 	// Exclude the beginning colon and terminating CRLF pair characters
 	var lrc lrc
-	lrc.reset()
 	lrc.pushByte(mb.SlaveID).pushByte(pdu.FunctionCode).pushBytes(pdu.Data)
 	if err = writeHex(&buf, []byte{lrc.value()}); err != nil {
 		return
@@ -154,7 +154,6 @@ func (mb *asciiPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 	}
 	// Calculate checksum
 	var lrc lrc
-	lrc.reset()
 	lrc.pushByte(address).pushByte(pdu.FunctionCode).pushBytes(pdu.Data)
 	if lrcVal != lrc.value() {
 		err = fmt.Errorf("modbus: response lrc '%v' does not match expected '%v'", lrcVal, lrc.value())

--- a/lrc.go
+++ b/lrc.go
@@ -9,14 +9,8 @@ type lrc struct {
 	sum uint8
 }
 
-func (lrc *lrc) pushByte(b byte) *lrc {
-	lrc.sum += b
-	return lrc
-}
-
-func (lrc *lrc) pushBytes(data []byte) *lrc {
-	var b byte
-	for _, b = range data {
+func (lrc *lrc) push(data ...byte) *lrc {
+	for _, b := range data {
 		lrc.sum += b
 	}
 	return lrc

--- a/lrc.go
+++ b/lrc.go
@@ -9,11 +9,6 @@ type lrc struct {
 	sum uint8
 }
 
-func (lrc *lrc) reset() *lrc {
-	lrc.sum = 0
-	return lrc
-}
-
 func (lrc *lrc) pushByte(b byte) *lrc {
 	lrc.sum += b
 	return lrc

--- a/lrc_test.go
+++ b/lrc_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestLRC(t *testing.T) {
 	var lrc lrc
-	lrc.reset().pushByte(0x01).pushByte(0x03)
+	lrc.pushByte(0x01).pushByte(0x03)
 	lrc.pushBytes([]byte{0x01, 0x0A})
 
 	if 0xF1 != lrc.value() {

--- a/lrc_test.go
+++ b/lrc_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestLRC(t *testing.T) {
 	var lrc lrc
-	lrc.pushByte(0x01).pushByte(0x03)
-	lrc.pushBytes([]byte{0x01, 0x0A})
+	lrc.push(0x01).push(0x03)
+	lrc.push([]byte{0x01, 0x0A}...)
 
 	if 0xF1 != lrc.value() {
 		t.Fatalf("lrc expected %v, actual %v", 0xF1, lrc.value())


### PR DESCRIPTION
`reset` is only ever used right after declaring the variable and hence pointless.