### PR TITLE
Simplify logger implementation

### DIFF
--- a/asciiclient.go
+++ b/asciiclient.go
@@ -34,7 +34,6 @@ func NewASCIIClientHandler(address string) *ASCIIClientHandler {
 	handler.Address = address
 	handler.Timeout = serialTimeout
 	handler.IdleTimeout = serialIdleTimeout
-	handler.serialPort.Logger = handler // expose the logger
 	return handler
 }
 
@@ -167,13 +166,6 @@ func (mb *asciiPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 // asciiSerialTransporter implements Transporter interface.
 type asciiSerialTransporter struct {
 	serialPort
-	Logger logger
-}
-
-func (mb *asciiSerialTransporter) Printf(format string, v ...interface{}) {
-	if mb.Logger != nil {
-		mb.Logger.Printf(format, v...)
-	}
 }
 
 func (mb *asciiSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -54,7 +54,6 @@ func NewRTUClientHandler(address string) *RTUClientHandler {
 	handler.Address = address
 	handler.Timeout = serialTimeout
 	handler.IdleTimeout = serialIdleTimeout
-	handler.serialPort.Logger = handler // expose the logger
 	return handler
 }
 
@@ -139,13 +138,6 @@ func (mb *rtuPackager) Decode(adu []byte) (pdu *ProtocolDataUnit, err error) {
 // rtuSerialTransporter implements Transporter interface.
 type rtuSerialTransporter struct {
 	serialPort
-	Logger logger
-}
-
-func (mb *rtuSerialTransporter) Printf(format string, v ...interface{}) {
-	if mb.Logger != nil {
-		mb.Logger.Printf(format, v...)
-	}
 }
 
 // InvalidLengthError is returned by readIncrementally when the modbus response would overflow buffer


### PR DESCRIPTION
Follow-up to https://github.com/grid-x/modbus/pull/31.

This PR removes the additional `Logger` fields. They should not be necessary- it seems that the serial port's logger actually *is* accessible externally. This is also non-breaking since the private field's hierarchy is not visible.