### PR TITLE
Make go doc comments compliant with `gofmt`

### DIFF
--- a/asciiclient.go
+++ b/asciiclient.go
@@ -54,13 +54,14 @@ func (mb *asciiPackager) SetSlave(slaveID byte) {
 	mb.SlaveID = slaveID
 }
 
-// Encode encodes PDU in a ASCII frame:
-//  Start           : 1 char
-//  Address         : 2 chars
-//  Function        : 2 chars
-//  Data            : 0 up to 2x252 chars
-//  LRC             : 2 chars
-//  End             : 2 chars
+// Encode encodes PDU in an ASCII frame:
+//
+//	Start           : 1 char
+//	Address         : 2 chars
+//	Function        : 2 chars
+//	Data            : 0 up to 2x252 chars
+//	LRC             : 2 chars
+//	End             : 2 chars
 func (mb *asciiPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	var buf bytes.Buffer
 

--- a/client.go
+++ b/client.go
@@ -37,13 +37,16 @@ func NewClient2(packager Packager, transporter Transporter) Client {
 }
 
 // Request:
-//  Function code         : 1 byte (0x01)
-//  Starting address      : 2 bytes
-//  Quantity of coils     : 2 bytes
+//
+//	Function code         : 1 byte (0x01)
+//	Starting address      : 2 bytes
+//	Quantity of coils     : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x01)
-//  Byte count            : 1 byte
-//  Coil status           : N* bytes (=N or N+1)
+//
+//	Function code         : 1 byte (0x01)
+//	Byte count            : 1 byte
+//	Coil status           : N* bytes (=N or N+1)
 func (mb *client) ReadCoils(address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 2000 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 2000)
@@ -68,13 +71,16 @@ func (mb *client) ReadCoils(address, quantity uint16) (results []byte, err error
 }
 
 // Request:
-//  Function code         : 1 byte (0x02)
-//  Starting address      : 2 bytes
-//  Quantity of inputs    : 2 bytes
+//
+//	Function code         : 1 byte (0x02)
+//	Starting address      : 2 bytes
+//	Quantity of inputs    : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x02)
-//  Byte count            : 1 byte
-//  Input status          : N* bytes (=N or N+1)
+//
+//	Function code         : 1 byte (0x02)
+//	Byte count            : 1 byte
+//	Input status          : N* bytes (=N or N+1)
 func (mb *client) ReadDiscreteInputs(address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 2000 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 2000)
@@ -99,13 +105,16 @@ func (mb *client) ReadDiscreteInputs(address, quantity uint16) (results []byte, 
 }
 
 // Request:
-//  Function code         : 1 byte (0x03)
-//  Starting address      : 2 bytes
-//  Quantity of registers : 2 bytes
+//
+//	Function code         : 1 byte (0x03)
+//	Starting address      : 2 bytes
+//	Quantity of registers : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x03)
-//  Byte count            : 1 byte
-//  Register value        : Nx2 bytes
+//
+//	Function code         : 1 byte (0x03)
+//	Byte count            : 1 byte
+//	Register value        : Nx2 bytes
 func (mb *client) ReadHoldingRegisters(address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 125 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 125)
@@ -130,13 +139,16 @@ func (mb *client) ReadHoldingRegisters(address, quantity uint16) (results []byte
 }
 
 // Request:
-//  Function code         : 1 byte (0x04)
-//  Starting address      : 2 bytes
-//  Quantity of registers : 2 bytes
+//
+//	Function code         : 1 byte (0x04)
+//	Starting address      : 2 bytes
+//	Quantity of registers : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x04)
-//  Byte count            : 1 byte
-//  Input registers       : N bytes
+//
+//	Function code         : 1 byte (0x04)
+//	Byte count            : 1 byte
+//	Input registers       : N bytes
 func (mb *client) ReadInputRegisters(address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 125 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 125)
@@ -161,13 +173,16 @@ func (mb *client) ReadInputRegisters(address, quantity uint16) (results []byte, 
 }
 
 // Request:
-//  Function code         : 1 byte (0x05)
-//  Output address        : 2 bytes
-//  Output value          : 2 bytes
+//
+//	Function code         : 1 byte (0x05)
+//	Output address        : 2 bytes
+//	Output value          : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x05)
-//  Output address        : 2 bytes
-//  Output value          : 2 bytes
+//
+//	Function code         : 1 byte (0x05)
+//	Output address        : 2 bytes
+//	Output value          : 2 bytes
 func (mb *client) WriteSingleCoil(address, value uint16) (results []byte, err error) {
 	// The requested ON/OFF state can only be 0xFF00 and 0x0000
 	if value != 0xFF00 && value != 0x0000 {
@@ -202,13 +217,16 @@ func (mb *client) WriteSingleCoil(address, value uint16) (results []byte, err er
 }
 
 // Request:
-//  Function code         : 1 byte (0x06)
-//  Register address      : 2 bytes
-//  Register value        : 2 bytes
+//
+//	Function code         : 1 byte (0x06)
+//	Register address      : 2 bytes
+//	Register value        : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x06)
-//  Register address      : 2 bytes
-//  Register value        : 2 bytes
+//
+//	Function code         : 1 byte (0x06)
+//	Register address      : 2 bytes
+//	Register value        : 2 bytes
 func (mb *client) WriteSingleRegister(address, value uint16) (results []byte, err error) {
 	request := ProtocolDataUnit{
 		FunctionCode: FuncCodeWriteSingleRegister,
@@ -238,15 +256,18 @@ func (mb *client) WriteSingleRegister(address, value uint16) (results []byte, er
 }
 
 // Request:
-//  Function code         : 1 byte (0x0F)
-//  Starting address      : 2 bytes
-//  Quantity of outputs   : 2 bytes
-//  Byte count            : 1 byte
-//  Outputs value         : N* bytes
+//
+//	Function code         : 1 byte (0x0F)
+//	Starting address      : 2 bytes
+//	Quantity of outputs   : 2 bytes
+//	Byte count            : 1 byte
+//	Outputs value         : N* bytes
+//
 // Response:
-//  Function code         : 1 byte (0x0F)
-//  Starting address      : 2 bytes
-//  Quantity of outputs   : 2 bytes
+//
+//	Function code         : 1 byte (0x0F)
+//	Starting address      : 2 bytes
+//	Quantity of outputs   : 2 bytes
 func (mb *client) WriteMultipleCoils(address, quantity uint16, value []byte) (results []byte, err error) {
 	if quantity < 1 || quantity > 1968 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 1968)
@@ -280,15 +301,18 @@ func (mb *client) WriteMultipleCoils(address, quantity uint16, value []byte) (re
 }
 
 // Request:
-//  Function code         : 1 byte (0x10)
-//  Starting address      : 2 bytes
-//  Quantity of outputs   : 2 bytes
-//  Byte count            : 1 byte
-//  Registers value       : N* bytes
+//
+//	Function code         : 1 byte (0x10)
+//	Starting address      : 2 bytes
+//	Quantity of outputs   : 2 bytes
+//	Byte count            : 1 byte
+//	Registers value       : N* bytes
+//
 // Response:
-//  Function code         : 1 byte (0x10)
-//  Starting address      : 2 bytes
-//  Quantity of registers : 2 bytes
+//
+//	Function code         : 1 byte (0x10)
+//	Starting address      : 2 bytes
+//	Quantity of registers : 2 bytes
 func (mb *client) WriteMultipleRegisters(address, quantity uint16, value []byte) (results []byte, err error) {
 	if quantity < 1 || quantity > 123 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 123)
@@ -322,15 +346,18 @@ func (mb *client) WriteMultipleRegisters(address, quantity uint16, value []byte)
 }
 
 // Request:
-//  Function code         : 1 byte (0x16)
-//  Reference address     : 2 bytes
-//  AND-mask              : 2 bytes
-//  OR-mask               : 2 bytes
+//
+//	Function code         : 1 byte (0x16)
+//	Reference address     : 2 bytes
+//	AND-mask              : 2 bytes
+//	OR-mask               : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x16)
-//  Reference address     : 2 bytes
-//  AND-mask              : 2 bytes
-//  OR-mask               : 2 bytes
+//
+//	Function code         : 1 byte (0x16)
+//	Reference address     : 2 bytes
+//	AND-mask              : 2 bytes
+//	OR-mask               : 2 bytes
 func (mb *client) MaskWriteRegister(address, andMask, orMask uint16) (results []byte, err error) {
 	request := ProtocolDataUnit{
 		FunctionCode: FuncCodeMaskWriteRegister,
@@ -365,17 +392,20 @@ func (mb *client) MaskWriteRegister(address, andMask, orMask uint16) (results []
 }
 
 // Request:
-//  Function code         : 1 byte (0x17)
-//  Read starting address : 2 bytes
-//  Quantity to read      : 2 bytes
-//  Write starting address: 2 bytes
-//  Quantity to write     : 2 bytes
-//  Write byte count      : 1 byte
-//  Write registers value : N* bytes
+//
+//	Function code         : 1 byte (0x17)
+//	Read starting address : 2 bytes
+//	Quantity to read      : 2 bytes
+//	Write starting address: 2 bytes
+//	Quantity to write     : 2 bytes
+//	Write byte count      : 1 byte
+//	Write registers value : N* bytes
+//
 // Response:
-//  Function code         : 1 byte (0x17)
-//  Byte count            : 1 byte
-//  Read registers value  : Nx2 bytes
+//
+//	Function code         : 1 byte (0x17)
+//	Byte count            : 1 byte
+//	Read registers value  : Nx2 bytes
 func (mb *client) ReadWriteMultipleRegisters(readAddress, readQuantity, writeAddress, writeQuantity uint16, value []byte) (results []byte, err error) {
 	if readQuantity < 1 || readQuantity > 125 {
 		err = fmt.Errorf("modbus: quantity to read '%v' must be between '%v' and '%v',", readQuantity, 1, 125)
@@ -403,14 +433,17 @@ func (mb *client) ReadWriteMultipleRegisters(readAddress, readQuantity, writeAdd
 }
 
 // Request:
-//  Function code         : 1 byte (0x18)
-//  FIFO pointer address  : 2 bytes
+//
+//	Function code         : 1 byte (0x18)
+//	FIFO pointer address  : 2 bytes
+//
 // Response:
-//  Function code         : 1 byte (0x18)
-//  Byte count            : 2 bytes
-//  FIFO count            : 2 bytes
-//  FIFO count            : 2 bytes (<=31)
-//  FIFO value register   : Nx2 bytes
+//
+//	Function code         : 1 byte (0x18)
+//	Byte count            : 2 bytes
+//	FIFO count            : 2 bytes
+//	FIFO count            : 2 bytes (<=31)
+//	FIFO value register   : Nx2 bytes
 func (mb *client) ReadFIFOQueue(address uint16) (results []byte, err error) {
 	request := ProtocolDataUnit{
 		FunctionCode: FuncCodeReadFIFOQueue,

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -74,11 +74,12 @@ func (mb *rtuPackager) SetSlave(slaveID byte) {
 	mb.SlaveID = slaveID
 }
 
-// Encode encodes PDU in a RTU frame:
-//  Slave Address   : 1 byte
-//  Function        : 1 byte
-//  Data            : 0 up to 252 bytes
-//  CRC             : 2 byte
+// Encode encodes PDU in an RTU frame:
+//
+//	Slave Address   : 1 byte
+//	Function        : 1 byte
+//	Data            : 0 up to 252 bytes
+//	CRC             : 2 byte
 func (mb *rtuPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	length := len(pdu.Data) + 4
 	if length > rtuMaxSize {
@@ -274,8 +275,8 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	if _, err = mb.port.Write(aduRequest); err != nil {
 		return
 	}
-	//function := aduRequest[1]
-	//functionFail := aduRequest[1] & 0x80
+	// function := aduRequest[1]
+	// functionFail := aduRequest[1] & 0x80
 	bytesToRead := calculateResponseLength(aduRequest)
 	time.Sleep(mb.calculateDelay(len(aduRequest) + bytesToRead))
 


### PR DESCRIPTION
Make go doc comments compliant with `gofmt` by replacing double spaces with bullet points.

This is the result of a discussion [here](https://github.com/grid-x/modbus/pull/66/files#r1158452083).