### PR TITLE
Fix races in unit-tests

### DIFF
--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -83,6 +83,8 @@ func TestTCPTransporter(t *testing.T) {
 		t.Fatalf("unexpected response: %x", rsp)
 	}
 	time.Sleep(150 * time.Millisecond)
+	client.mu.Lock()
+	defer client.mu.Unlock()
 	if client.conn != nil {
 		t.Fatalf("connection is not closed: %+v", client.conn)
 	}


### PR DESCRIPTION
Running `go test -v -race` will report two races, one for `TestSerialCloseIdle` and one for `TestTCPTransporter` (see excerpt below). This PR fixes the races in both tests.

```text
=== RUN   TestSerialCloseIdle
==================
WARNING: DATA RACE
Read at 0x00c000244088 by goroutine 42:
  github.com/grid-x/modbus.TestSerialCloseIdle()
      /home/sven/Development/InfluxData/modbus/serial_test.go:33 +0x255
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1648 +0x44

Previous write at 0x00c000244088 by goroutine 44:
  github.com/grid-x/modbus.(*nopCloser).Close()
      /home/sven/Development/InfluxData/modbus/serial_test.go:17 +0x2f
  github.com/grid-x/modbus.(*serialPort).close()
      /home/sven/Development/InfluxData/modbus/serial.go:66 +0x282
  github.com/grid-x/modbus.(*serialPort).closeIdle()
      /home/sven/Development/InfluxData/modbus/serial.go:100 +0x23f
  github.com/grid-x/modbus.(*serialPort).closeIdle-fm()
      <autogenerated>:1 +0x33

Goroutine 42 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:1648 +0x845
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x261
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:2052 +0x8ad
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1925 +0xcd7
  main.main()
      _testmain.go:91 +0x2bd

Goroutine 44 (finished) created at:
  time.goFunc()
      /usr/lib/go/src/time/sleep.go:176 +0x44
==================
==================
WARNING: DATA RACE
Read at 0x00c00026a080 by goroutine 42:
  github.com/grid-x/modbus.TestSerialCloseIdle()
      /home/sven/Development/InfluxData/modbus/serial_test.go:33 +0x27c
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1648 +0x44

Previous write at 0x00c00026a080 by goroutine 44:
  github.com/grid-x/modbus.(*serialPort).close()
      /home/sven/Development/InfluxData/modbus/serial.go:67 +0x28f
  github.com/grid-x/modbus.(*serialPort).closeIdle()
      /home/sven/Development/InfluxData/modbus/serial.go:100 +0x23f
  github.com/grid-x/modbus.(*serialPort).closeIdle-fm()
      <autogenerated>:1 +0x33

Goroutine 42 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:1648 +0x845
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x261
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:2052 +0x8ad
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1925 +0xcd7
  main.main()
      _testmain.go:91 +0x2bd

Goroutine 44 (finished) created at:
  time.goFunc()
      /usr/lib/go/src/time/sleep.go:176 +0x44
==================
    testing.go:1465: race detected during execution of test
--- FAIL: TestSerialCloseIdle (0.15s)
```
and
```text
=== RUN   TestTCPTransporter
==================
WARNING: DATA RACE
Read at 0x00c0001360e0 by goroutine 48:
  github.com/grid-x/modbus.TestTCPTransporter()
      /home/sven/Development/InfluxData/modbus/tcpclient_test.go:86 +0x5cd
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1648 +0x44

Previous write at 0x00c0001360e0 by goroutine 52:
  github.com/grid-x/modbus.(*tcpTransporter).close()
      /home/sven/Development/InfluxData/modbus/tcpclient.go:395 +0x275
  github.com/grid-x/modbus.(*tcpTransporter).closeIdle()
      /home/sven/Development/InfluxData/modbus/tcpclient.go:411 +0x22e
  github.com/grid-x/modbus.(*tcpTransporter).closeIdle-fm()
      <autogenerated>:1 +0x33

Goroutine 48 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:1648 +0x845
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x261
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:2052 +0x8ad
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1925 +0xcd7
  main.main()
      _testmain.go:91 +0x2bd

Goroutine 52 (finished) created at:
  time.goFunc()
      /usr/lib/go/src/time/sleep.go:176 +0x44
==================
    testing.go:1465: race detected during execution of test
--- FAIL: TestTCPTransporter (0.15s)
```