### PR TITLE
chore: Bring back ability to use a custom logger

### DIFF
--- a/modbus.go
+++ b/modbus.go
@@ -8,6 +8,7 @@ Package modbus provides a client for MODBUS TCP and RTU/ASCII.
 package modbus
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -115,4 +116,16 @@ type Transporter interface {
 type Connector interface {
 	Connect() error
 	Close() error
+}
+
+// Logger is an interface to define custom loggers
+type Logger interface {
+	Debug(string, ...any)
+	DebugContext(context.Context, string, ...any)
+	Info(string, ...any)
+	InfoContext(context.Context, string, ...any)
+	Warn(string, ...any)
+	WarnContext(context.Context, string, ...any)
+	Error(string, ...any)
+	ErrorContext(context.Context, string, ...any)
 }

--- a/rtu_over_udp_client.go
+++ b/rtu_over_udp_client.go
@@ -3,7 +3,6 @@ package modbus
 import (
 	"fmt"
 	"io"
-	logger "log/slog"
 	"net"
 	"sync"
 )
@@ -46,7 +45,7 @@ type rtuUDPTransporter struct {
 	// Connect string
 	Address string
 	// Transmission logger
-	Logger *logger.Logger
+	Logger Logger
 
 	// UDP connection
 	mu   sync.Mutex

--- a/serial.go
+++ b/serial.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"sync"
 	"time"
 
@@ -26,7 +25,7 @@ type serialPort struct {
 	// Serial port configuration.
 	serial.Config
 
-	Logger      *slog.Logger
+	Logger      Logger
 	IdleTimeout time.Duration
 
 	mu sync.Mutex

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -138,7 +137,7 @@ type tcpTransporter struct {
 	// Silent period after successful connection
 	ConnectDelay time.Duration
 	// Transmission logger
-	Logger *slog.Logger
+	Logger Logger
 
 	// TCP connection
 	mu           sync.Mutex


### PR DESCRIPTION
When using this project as a modbus library it is beneficial to be able to use a custom logger to e.g. output the information in a common and consistent form or to use sinks not provided by slog.

This PR abstracts the logging to an interface closely following the notion of `slog.Logger` to allow an easy direct use of slog. As such, the change is **fully backward compatible**. However, this allows users of the library to define custom loggers.

resolves #79 