### PR TITLE
Fix calculating RTU over serial frame delay

### DIFF
--- a/rtuclient.go
+++ b/rtuclient.go
@@ -168,7 +168,7 @@ func readIncrementally(slaveID, functionCode byte, r io.Reader, delay time.Durat
 
 	for {
 		if !deadline.IsZero() && time.Now().After(deadline) { // Possible that serialport may spew data
-			return nil, fmt.Errorf("failed to read from serial port within deadline")
+			return nil, errors.New("failed to read from serial port within deadline")
 		}
 
 		if _, err := io.ReadAtLeast(r, buf, 1); err != nil {

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -174,14 +174,14 @@ func readIncrementally(slaveID, functionCode byte, r io.Reader, delay time.Durat
 			return nil, err
 		}
 
-		// after response has started remaining bytes MUST be read within maximum message duration
-		if delay > 0 {
-			deadline = time.Now().Add(delay)
-		}
-
 		switch state {
 		// expecting slaveID
 		case stateSlaveID:
+			// after response has started remaining bytes MUST be read within maximum message duration
+			if delay > 0 {
+				deadline = time.Now().Add(delay)
+			}
+
 			// read slaveID
 			if buf[0] == slaveID {
 				state = stateFunctionCode

--- a/rtuclient_test.go
+++ b/rtuclient_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestRTUEncoding(t *testing.T) {
@@ -331,7 +330,7 @@ func Test_readIncrementally(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
-			got, err := readIncrementally(tc.slaveID, tc.functionCode, bytes.NewBuffer(tc.data), time.Now().Add(time.Second*5))
+			got, err := readIncrementally(tc.slaveID, tc.functionCode, bytes.NewBuffer(tc.data), 0)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error but did not get one")


### PR DESCRIPTION
In https://github.com/evcc-io/evcc/issues/16049 we're regularly experiencing timeout errors with multiple devices on a single serial bus. It turns out the frame length calculation according to theMODBUS over Serial Line Specification and Implementation Guide is not correctly implemented. The calculation misses the fact that it needs to honor not only the character gap but also the character duration and it skips the frame interval to the following write. 