### PR TITLE
Allow overriding Dial function in TCP client handler

### DIFF
--- a/ascii_over_tcp_client.go
+++ b/ascii_over_tcp_client.go
@@ -5,6 +5,7 @@
 package modbus
 
 import (
+	"net"
 	"time"
 )
 
@@ -20,6 +21,7 @@ func NewASCIIOverTCPClientHandler(address string) *ASCIIOverTCPClientHandler {
 	handler.Address = address
 	handler.Timeout = tcpTimeout
 	handler.IdleTimeout = tcpIdleTimeout
+	handler.Dial = defaultDialFunc(handler.Timeout)
 	return handler
 }
 

--- a/rtu_over_tcp_client.go
+++ b/rtu_over_tcp_client.go
@@ -6,6 +6,7 @@ package modbus
 
 import (
 	"io"
+	"net"
 	"time"
 )
 
@@ -21,6 +22,7 @@ func NewRTUOverTCPClientHandler(address string) *RTUOverTCPClientHandler {
 	handler.Address = address
 	handler.Timeout = tcpTimeout
 	handler.IdleTimeout = tcpIdleTimeout
+	handler.Dial = defaultDialFunc(handler.Timeout)
 	return handler
 }
 


### PR DESCRIPTION
Allows customizing the Client function that is used for dialing new connections.

The primary envisioned use case is to enable the outsourcing of network connections to an external connection manager (pool):

```go
var cm extpkg.ConnectionManager

modbus.NewTCPClientHandler(
    modbus.WithDialer(func(ctx context.Context, _, addr string) (net.Conn, error) {
        // acquire new connection inside the closure
       return cm.TCPConn(ctx, address)
    })
)
```

The default Dial function remains `net.Dial`.