### PR TITLE
feat!: implement cancelation across clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Basic usage:
 // Modbus TCP
 client := modbus.TCPClient("localhost:502")
 // Read input register 9
-results, err := client.ReadInputRegisters(8, 1)
+results, err := client.ReadInputRegisters(context.Background(), 8, 1)
 
 // Modbus RTU/ASCII
 // Default configuration is 19200, 8, 1, even
 client = modbus.RTUClient("/dev/ttyS0")
-results, err = client.ReadCoils(2, 1)
+results, err = client.ReadCoils(context.Background(), 2, 1)
 ```
 
 Advanced usage:
@@ -44,14 +44,15 @@ handler := modbus.NewTCPClientHandler("localhost:502")
 handler.Timeout = 10 * time.Second
 handler.SlaveID = 0xFF
 handler.Logger = log.New(os.Stdout, "test: ", log.LstdFlags)
+ctx := context.Background()
 // Connect manually so that multiple requests are handled in one connection session
-err := handler.Connect()
+err := handler.Connect(ctx)
 defer handler.Close()
 
 client := modbus.NewClient(handler)
-results, err := client.ReadDiscreteInputs(15, 2)
-results, err = client.WriteMultipleRegisters(1, 2, []byte{0, 3, 0, 4})
-results, err = client.WriteMultipleCoils(5, 10, []byte{4, 3})
+results, err := client.ReadDiscreteInputs(ctx, 15, 2)
+results, err = client.WriteMultipleRegisters(ctx, 1, 2, []byte{0, 3, 0, 4})
+results, err = client.WriteMultipleCoils(ctx, 5, 10, []byte{4, 3})
 ```
 
 ```go
@@ -64,11 +65,12 @@ handler.StopBits = 1
 handler.SlaveID = 1
 handler.Timeout = 5 * time.Second
 
-err := handler.Connect()
+ctx := context.Background()
+err := handler.Connect(ctx)
 defer handler.Close()
 
 client := modbus.NewClient(handler)
-results, err := client.ReadDiscreteInputs(15, 2)
+results, err := client.ReadDiscreteInputs(ctx, 15, 2)
 ```
 
 # Modbus-CLI

--- a/api.go
+++ b/api.go
@@ -4,47 +4,49 @@
 
 package modbus
 
+import "context"
+
 // Client declares the functionality of a Modbus client regardless of the underlying transport stream.
 type Client interface {
 	// Bit access
 
 	// ReadCoils reads from 1 to 2000 contiguous status of coils in a
 	// remote device and returns coil status.
-	ReadCoils(address, quantity uint16) (results []byte, err error)
+	ReadCoils(ctx context.Context, address, quantity uint16) (results []byte, err error)
 	// ReadDiscreteInputs reads from 1 to 2000 contiguous status of
 	// discrete inputs in a remote device and returns input status.
-	ReadDiscreteInputs(address, quantity uint16) (results []byte, err error)
+	ReadDiscreteInputs(ctx context.Context, address, quantity uint16) (results []byte, err error)
 	// WriteSingleCoil write a single output to either ON or OFF in a
 	// remote device and returns output value.
-	WriteSingleCoil(address, value uint16) (results []byte, err error)
+	WriteSingleCoil(ctx context.Context, address, value uint16) (results []byte, err error)
 	// WriteMultipleCoils forces each coil in a sequence of coils to either
 	// ON or OFF in a remote device and returns quantity of outputs.
-	WriteMultipleCoils(address, quantity uint16, value []byte) (results []byte, err error)
+	WriteMultipleCoils(ctx context.Context, address, quantity uint16, value []byte) (results []byte, err error)
 
 	// 16-bit access
 
 	// ReadInputRegisters reads from 1 to 125 contiguous input registers in
 	// a remote device and returns input registers.
-	ReadInputRegisters(address, quantity uint16) (results []byte, err error)
+	ReadInputRegisters(ctx context.Context, address, quantity uint16) (results []byte, err error)
 	// ReadHoldingRegisters reads the contents of a contiguous block of
 	// holding registers in a remote device and returns register value.
-	ReadHoldingRegisters(address, quantity uint16) (results []byte, err error)
+	ReadHoldingRegisters(ctx context.Context, address, quantity uint16) (results []byte, err error)
 	// WriteSingleRegister writes a single holding register in a remote
 	// device and returns register value.
-	WriteSingleRegister(address, value uint16) (results []byte, err error)
+	WriteSingleRegister(ctx context.Context, address, value uint16) (results []byte, err error)
 	// WriteMultipleRegisters writes a block of contiguous registers
 	// (1 to 123 registers) in a remote device and returns quantity of
 	// registers.
-	WriteMultipleRegisters(address, quantity uint16, value []byte) (results []byte, err error)
+	WriteMultipleRegisters(ctx context.Context, address, quantity uint16, value []byte) (results []byte, err error)
 	// ReadWriteMultipleRegisters performs a combination of one read
 	// operation and one write operation. It returns read registers value.
-	ReadWriteMultipleRegisters(readAddress, readQuantity, writeAddress, writeQuantity uint16, value []byte) (results []byte, err error)
+	ReadWriteMultipleRegisters(ctx context.Context, readAddress, readQuantity, writeAddress, writeQuantity uint16, value []byte) (results []byte, err error)
 	// MaskWriteRegister modify the contents of a specified holding
 	// register using a combination of an AND mask, an OR mask, and the
 	// register's current contents. The function returns
 	// AND-mask and OR-mask.
-	MaskWriteRegister(address, andMask, orMask uint16) (results []byte, err error)
+	MaskWriteRegister(ctx context.Context, address, andMask, orMask uint16) (results []byte, err error)
 	//ReadFIFOQueue reads the contents of a First-In-First-Out (FIFO) queue
 	// of register in a remote device and returns FIFO value register.
-	ReadFIFOQueue(address uint16) (results []byte, err error)
+	ReadFIFOQueue(ctx context.Context, address uint16) (results []byte, err error)
 }

--- a/ascii_over_tcp_client.go
+++ b/ascii_over_tcp_client.go
@@ -4,7 +4,10 @@
 
 package modbus
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // ASCIIOverTCPClientHandler implements Packager and Transporter interface.
 type ASCIIOverTCPClientHandler struct {
@@ -33,12 +36,12 @@ type asciiTCPTransporter struct {
 	tcpTransporter
 }
 
-func (mb *asciiTCPTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
+func (mb *asciiTCPTransporter) Send(ctx context.Context, aduRequest []byte) (aduResponse []byte, err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 
 	// Make sure port is connected
-	if err = mb.connect(); err != nil {
+	if err = mb.connect(ctx); err != nil {
 		return
 	}
 	// Start the timer to close when idle

--- a/asciiclient.go
+++ b/asciiclient.go
@@ -6,6 +6,7 @@ package modbus
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -168,12 +169,12 @@ type asciiSerialTransporter struct {
 	serialPort
 }
 
-func (mb *asciiSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
+func (mb *asciiSerialTransporter) Send(ctx context.Context, aduRequest []byte) (aduResponse []byte, err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 
 	// Make sure port is connected
-	if err = mb.connect(); err != nil {
+	if err = mb.connect(ctx); err != nil {
 		return
 	}
 	// Start the timer to close when idle

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@
 package modbus
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 )
@@ -58,7 +59,7 @@ func NewClient2(packager Packager, transporter Transporter) Client {
 //	Function code         : 1 byte (0x01)
 //	Byte count            : 1 byte
 //	Coil status           : N* bytes (=N or N+1)
-func (mb *client) ReadCoils(address, quantity uint16) (results []byte, err error) {
+func (mb *client) ReadCoils(ctx context.Context, address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 2000 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 2000)
 		return
@@ -67,7 +68,7 @@ func (mb *client) ReadCoils(address, quantity uint16) (results []byte, err error
 		FunctionCode: FuncCodeReadCoils,
 		Data:         dataBlock(address, quantity),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -94,7 +95,7 @@ func (mb *client) ReadCoils(address, quantity uint16) (results []byte, err error
 //	Function code         : 1 byte (0x02)
 //	Byte count            : 1 byte
 //	Input status          : N* bytes (=N or N+1)
-func (mb *client) ReadDiscreteInputs(address, quantity uint16) (results []byte, err error) {
+func (mb *client) ReadDiscreteInputs(ctx context.Context, address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 2000 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 2000)
 		return
@@ -103,7 +104,7 @@ func (mb *client) ReadDiscreteInputs(address, quantity uint16) (results []byte, 
 		FunctionCode: FuncCodeReadDiscreteInputs,
 		Data:         dataBlock(address, quantity),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -130,7 +131,7 @@ func (mb *client) ReadDiscreteInputs(address, quantity uint16) (results []byte, 
 //	Function code         : 1 byte (0x03)
 //	Byte count            : 1 byte
 //	Register value        : Nx2 bytes
-func (mb *client) ReadHoldingRegisters(address, quantity uint16) (results []byte, err error) {
+func (mb *client) ReadHoldingRegisters(ctx context.Context, address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 125 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 125)
 		return
@@ -139,7 +140,7 @@ func (mb *client) ReadHoldingRegisters(address, quantity uint16) (results []byte
 		FunctionCode: FuncCodeReadHoldingRegisters,
 		Data:         dataBlock(address, quantity),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -170,7 +171,7 @@ func (mb *client) ReadHoldingRegisters(address, quantity uint16) (results []byte
 //	Function code         : 1 byte (0x04)
 //	Byte count            : 1 byte
 //	Input registers       : N bytes
-func (mb *client) ReadInputRegisters(address, quantity uint16) (results []byte, err error) {
+func (mb *client) ReadInputRegisters(ctx context.Context, address, quantity uint16) (results []byte, err error) {
 	if quantity < 1 || quantity > 125 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 125)
 		return
@@ -179,7 +180,7 @@ func (mb *client) ReadInputRegisters(address, quantity uint16) (results []byte, 
 		FunctionCode: FuncCodeReadInputRegisters,
 		Data:         dataBlock(address, quantity),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -210,7 +211,7 @@ func (mb *client) ReadInputRegisters(address, quantity uint16) (results []byte, 
 //	Function code         : 1 byte (0x05)
 //	Output address        : 2 bytes
 //	Output value          : 2 bytes
-func (mb *client) WriteSingleCoil(address, value uint16) (results []byte, err error) {
+func (mb *client) WriteSingleCoil(ctx context.Context, address, value uint16) (results []byte, err error) {
 	// The requested ON/OFF state can only be 0xFF00 and 0x0000
 	if value != 0xFF00 && value != 0x0000 {
 		err = fmt.Errorf("modbus: state '%v' must be either 0xFF00 (ON) or 0x0000 (OFF)", value)
@@ -220,7 +221,7 @@ func (mb *client) WriteSingleCoil(address, value uint16) (results []byte, err er
 		FunctionCode: FuncCodeWriteSingleCoil,
 		Data:         dataBlock(address, value),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -254,12 +255,12 @@ func (mb *client) WriteSingleCoil(address, value uint16) (results []byte, err er
 //	Function code         : 1 byte (0x06)
 //	Register address      : 2 bytes
 //	Register value        : 2 bytes
-func (mb *client) WriteSingleRegister(address, value uint16) (results []byte, err error) {
+func (mb *client) WriteSingleRegister(ctx context.Context, address, value uint16) (results []byte, err error) {
 	request := ProtocolDataUnit{
 		FunctionCode: FuncCodeWriteSingleRegister,
 		Data:         dataBlock(address, value),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -295,7 +296,7 @@ func (mb *client) WriteSingleRegister(address, value uint16) (results []byte, er
 //	Function code         : 1 byte (0x0F)
 //	Starting address      : 2 bytes
 //	Quantity of outputs   : 2 bytes
-func (mb *client) WriteMultipleCoils(address, quantity uint16, value []byte) (results []byte, err error) {
+func (mb *client) WriteMultipleCoils(ctx context.Context, address, quantity uint16, value []byte) (results []byte, err error) {
 	if quantity < 1 || quantity > 1968 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 1968)
 		return
@@ -304,7 +305,7 @@ func (mb *client) WriteMultipleCoils(address, quantity uint16, value []byte) (re
 		FunctionCode: FuncCodeWriteMultipleCoils,
 		Data:         dataBlockSuffix(value, address, quantity),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -340,7 +341,7 @@ func (mb *client) WriteMultipleCoils(address, quantity uint16, value []byte) (re
 //	Function code         : 1 byte (0x10)
 //	Starting address      : 2 bytes
 //	Quantity of registers : 2 bytes
-func (mb *client) WriteMultipleRegisters(address, quantity uint16, value []byte) (results []byte, err error) {
+func (mb *client) WriteMultipleRegisters(ctx context.Context, address, quantity uint16, value []byte) (results []byte, err error) {
 	if quantity < 1 || quantity > 123 {
 		err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 123)
 		return
@@ -349,7 +350,7 @@ func (mb *client) WriteMultipleRegisters(address, quantity uint16, value []byte)
 		FunctionCode: FuncCodeWriteMultipleRegisters,
 		Data:         dataBlockSuffix(value, address, quantity),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -385,12 +386,12 @@ func (mb *client) WriteMultipleRegisters(address, quantity uint16, value []byte)
 //	Reference address     : 2 bytes
 //	AND-mask              : 2 bytes
 //	OR-mask               : 2 bytes
-func (mb *client) MaskWriteRegister(address, andMask, orMask uint16) (results []byte, err error) {
+func (mb *client) MaskWriteRegister(ctx context.Context, address, andMask, orMask uint16) (results []byte, err error) {
 	request := ProtocolDataUnit{
 		FunctionCode: FuncCodeMaskWriteRegister,
 		Data:         dataBlock(address, andMask, orMask),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -433,7 +434,7 @@ func (mb *client) MaskWriteRegister(address, andMask, orMask uint16) (results []
 //	Function code         : 1 byte (0x17)
 //	Byte count            : 1 byte
 //	Read registers value  : Nx2 bytes
-func (mb *client) ReadWriteMultipleRegisters(readAddress, readQuantity, writeAddress, writeQuantity uint16, value []byte) (results []byte, err error) {
+func (mb *client) ReadWriteMultipleRegisters(ctx context.Context, readAddress, readQuantity, writeAddress, writeQuantity uint16, value []byte) (results []byte, err error) {
 	if readQuantity < 1 || readQuantity > 125 {
 		err = fmt.Errorf("modbus: quantity to read '%v' must be between '%v' and '%v',", readQuantity, 1, 125)
 		return
@@ -446,7 +447,7 @@ func (mb *client) ReadWriteMultipleRegisters(readAddress, readQuantity, writeAdd
 		FunctionCode: FuncCodeReadWriteMultipleRegisters,
 		Data:         dataBlockSuffix(value, readAddress, readQuantity, writeAddress, writeQuantity),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -474,12 +475,12 @@ func (mb *client) ReadWriteMultipleRegisters(readAddress, readQuantity, writeAdd
 //	FIFO count            : 2 bytes
 //	FIFO count            : 2 bytes (<=31)
 //	FIFO value register   : Nx2 bytes
-func (mb *client) ReadFIFOQueue(address uint16) (results []byte, err error) {
+func (mb *client) ReadFIFOQueue(ctx context.Context, address uint16) (results []byte, err error) {
 	request := ProtocolDataUnit{
 		FunctionCode: FuncCodeReadFIFOQueue,
 		Data:         dataBlock(address),
 	}
-	response, err := mb.send(&request)
+	response, err := mb.send(ctx, &request)
 	if err != nil {
 		return
 	}
@@ -507,12 +508,12 @@ func (mb *client) ReadFIFOQueue(address uint16) (results []byte, err error) {
 // Helpers
 
 // send sends request and checks possible exception in the response.
-func (mb *client) send(request *ProtocolDataUnit) (response *ProtocolDataUnit, err error) {
+func (mb *client) send(ctx context.Context, request *ProtocolDataUnit) (response *ProtocolDataUnit, err error) {
 	aduRequest, err := mb.packager.Encode(request)
 	if err != nil {
 		return
 	}
-	aduResponse, err := mb.transporter.Send(aduRequest)
+	aduResponse, err := mb.transporter.Send(ctx, aduRequest)
 	if err != nil {
 		return
 	}

--- a/modbus.go
+++ b/modbus.go
@@ -8,6 +8,7 @@ Package modbus provides a client for MODBUS TCP and RTU/ASCII.
 package modbus
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -108,11 +109,11 @@ type Packager interface {
 
 // Transporter specifies the transport layer.
 type Transporter interface {
-	Send(aduRequest []byte) (aduResponse []byte, err error)
+	Send(ctx context.Context, aduRequest []byte) (aduResponse []byte, err error)
 }
 
 // Connector exposes the underlying handler capability for open/connect and close the transport channel.
 type Connector interface {
-	Connect() error
+	Connect(ctx context.Context) error
 	Close() error
 }

--- a/rtu_over_tcp_client.go
+++ b/rtu_over_tcp_client.go
@@ -5,6 +5,7 @@
 package modbus
 
 import (
+	"context"
 	"io"
 	"time"
 )
@@ -37,12 +38,12 @@ type rtuTCPTransporter struct {
 }
 
 // Send sends data to server and ensures adequate response for request type
-func (mb *rtuTCPTransporter) Send(aduRequest []byte) (aduResponse []byte, err error) {
+func (mb *rtuTCPTransporter) Send(ctx context.Context, aduRequest []byte) (aduResponse []byte, err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 
 	// Establish a new connection if not connected
-	if err = mb.connect(); err != nil {
+	if err = mb.connect(ctx); err != nil {
 		return
 	}
 	// Set timer to close when idle

--- a/serial.go
+++ b/serial.go
@@ -5,6 +5,7 @@
 package modbus
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -34,15 +35,20 @@ type serialPort struct {
 	closeTimer   *time.Timer
 }
 
-func (mb *serialPort) Connect() (err error) {
+func (mb *serialPort) Connect(ctx context.Context) (err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
 
-	return mb.connect()
+	return mb.connect(ctx)
 }
 
 // connect connects to the serial port if it is not connected. Caller must hold the mutex.
-func (mb *serialPort) connect() error {
+func (mb *serialPort) connect(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 	if mb.port == nil {
 		port, err := serial.Open(&mb.Config)
 		if err != nil {

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -250,7 +250,11 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 		mb.logf("modbus: close connection and retry, because of %v", err)
 
 		mb.close()
-		time.Sleep(mb.LinkRecoveryTimeout)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(mb.LinkRecoveryTimeout):
+		}
 	}
 }
 

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -87,7 +87,7 @@ func TestTCPTransporter(t *testing.T) {
 		Dial:        defaultDialFunc(1 * time.Second),
 	}
 	req := []byte{0, 1, 0, 2, 0, 2, 1, 2}
-	rsp, err := client.Send(req)
+	rsp, err := client.Send(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,18 +166,19 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 	handler := NewTCPClientHandler(ln.Addr().String())
 	handler.Timeout = 1 * time.Second
 	handler.ProtocolRecoveryTimeout = 50 * time.Millisecond
+	ctx := context.Background()
 	client := NewClient(handler)
-	_, err = client.ReadInputRegisters(0, 1)
+	_, err = client.ReadInputRegisters(ctx, 0, 1)
 	opError, ok := err.(*net.OpError)
 	if !ok || !opError.Timeout() {
 		t.Fatalf("expected timeout error, got %q", err)
 	}
-	_, err = client.ReadInputRegisters(0, 1)
+	_, err = client.ReadInputRegisters(ctx, 0, 1)
 	opError, ok = err.(*net.OpError)
 	if !ok || !opError.Timeout() {
 		t.Fatalf("expected timeout error, got %q", err)
 	}
-	resp, err := client.ReadInputRegisters(0, 1)
+	resp, err := client.ReadInputRegisters(ctx, 0, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +250,7 @@ func TestCustomDialer(t *testing.T) {
 	// Asserts that the response comes from the expected server.
 	assertResponse := func(t *testing.T, c Client) {
 		t.Helper()
-		res, err := c.ReadInputRegisters(tRegisterNum, qtyUint32)
+		res, err := c.ReadInputRegisters(context.Background(), tRegisterNum, qtyUint32)
 		if err != nil {
 			t.Fatal("ReadInputRegisters:", err)
 		}
@@ -405,7 +406,7 @@ func TestConnCaching(t *testing.T) {
 	// Calls ReadInputRegisters with test parameters.
 	doSend := func(c Client) error {
 		const qtyUint32 = 2
-		_, err := c.ReadInputRegisters(0xCAFE, qtyUint32)
+		_, err := c.ReadInputRegisters(context.Background(), 0xCAFE, qtyUint32)
 		return err
 	}
 

--- a/test/asciiclient_test.go
+++ b/test/asciiclient_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"context"
 	"log"
 	"testing"
 
@@ -30,18 +31,19 @@ func TestASCIIClientAdvancedUsage(t *testing.T) {
 	handler.StopBits = 1
 	handler.SlaveID = 12
 	handler.Logger = log.Default()
-	err := handler.Connect()
+	ctx := context.Background()
+	err := handler.Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer handler.Close()
 
 	client := modbus.NewClient(handler)
-	results, err := client.ReadDiscreteInputs(15, 2)
+	results, err := client.ReadDiscreteInputs(ctx, 15, 2)
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}
-	results, err = client.ReadWriteMultipleRegisters(0, 2, 2, 2, []byte{1, 2, 3, 4})
+	results, err = client.ReadWriteMultipleRegisters(ctx, 0, 2, 2, 2, []byte{1, 2, 3, 4})
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}

--- a/test/client.go
+++ b/test/client.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grid-x/modbus"
@@ -14,7 +15,7 @@ func ClientTestReadCoils(t *testing.T, client modbus.Client) {
 	// Read discrete outputs 20-38:
 	address := uint16(0x0013)
 	quantity := uint16(0x0013)
-	results, err := client.ReadCoils(address, quantity)
+	results, err := client.ReadCoils(context.Background(), address, quantity)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +26,7 @@ func ClientTestReadDiscreteInputs(t *testing.T, client modbus.Client) {
 	// Read discrete inputs 197-218
 	address := uint16(0x00C4)
 	quantity := uint16(0x0016)
-	results, err := client.ReadDiscreteInputs(address, quantity)
+	results, err := client.ReadDiscreteInputs(context.Background(), address, quantity)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +37,7 @@ func ClientTestReadHoldingRegisters(t *testing.T, client modbus.Client) {
 	// Read registers 108-110
 	address := uint16(0x006B)
 	quantity := uint16(0x0003)
-	results, err := client.ReadHoldingRegisters(address, quantity)
+	results, err := client.ReadHoldingRegisters(context.Background(), address, quantity)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +48,7 @@ func ClientTestReadInputRegisters(t *testing.T, client modbus.Client) {
 	// Read input register 9
 	address := uint16(0x0008)
 	quantity := uint16(0x0001)
-	results, err := client.ReadInputRegisters(address, quantity)
+	results, err := client.ReadInputRegisters(context.Background(), address, quantity)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +59,7 @@ func ClientTestWriteSingleCoil(t *testing.T, client modbus.Client) {
 	// Write coil 173 ON
 	address := uint16(0x00AC)
 	value := uint16(0xFF00)
-	results, err := client.WriteSingleCoil(address, value)
+	results, err := client.WriteSingleCoil(context.Background(), address, value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,7 @@ func ClientTestWriteSingleRegister(t *testing.T, client modbus.Client) {
 	// Write register 2 to 00 03 hex
 	address := uint16(0x0001)
 	value := uint16(0x0003)
-	results, err := client.WriteSingleRegister(address, value)
+	results, err := client.WriteSingleRegister(context.Background(), address, value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +82,7 @@ func ClientTestWriteMultipleCoils(t *testing.T, client modbus.Client) {
 	address := uint16(0x0013)
 	quantity := uint16(0x000A)
 	values := []byte{0xCD, 0x01}
-	results, err := client.WriteMultipleCoils(address, quantity, values)
+	results, err := client.WriteMultipleCoils(context.Background(), address, quantity, values)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +94,7 @@ func ClientTestWriteMultipleRegisters(t *testing.T, client modbus.Client) {
 	address := uint16(0x0001)
 	quantity := uint16(0x0002)
 	values := []byte{0x00, 0x0A, 0x01, 0x02}
-	results, err := client.WriteMultipleRegisters(address, quantity, values)
+	results, err := client.WriteMultipleRegisters(context.Background(), address, quantity, values)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +106,7 @@ func ClientTestMaskWriteRegisters(t *testing.T, client modbus.Client) {
 	address := uint16(0x0004)
 	andMask := uint16(0x00F2)
 	orMask := uint16(0x0025)
-	results, err := client.MaskWriteRegister(address, andMask, orMask)
+	results, err := client.MaskWriteRegister(context.Background(), address, andMask, orMask)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +120,7 @@ func ClientTestReadWriteMultipleRegisters(t *testing.T, client modbus.Client) {
 	writeAddress := uint16(0x000E)
 	writeQuantity := uint16(0x0003)
 	values := []byte{0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF}
-	results, err := client.ReadWriteMultipleRegisters(address, quantity, writeAddress, writeQuantity, values)
+	results, err := client.ReadWriteMultipleRegisters(context.Background(), address, quantity, writeAddress, writeQuantity, values)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +130,7 @@ func ClientTestReadWriteMultipleRegisters(t *testing.T, client modbus.Client) {
 func ClientTestReadFIFOQueue(t *testing.T, client modbus.Client) {
 	// Read queue starting at the pointer register 1246
 	address := uint16(0x04DE)
-	results, err := client.ReadFIFOQueue(address)
+	results, err := client.ReadFIFOQueue(context.Background(), address)
 	// Server not implemented
 	if err != nil {
 		AssertEquals(t, "modbus: exception '1' (illegal function), function '24'", err.Error())

--- a/test/rtu_over_tcp_client_test.go
+++ b/test/rtu_over_tcp_client_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"context"
 	"log"
 	"testing"
 	"time"
@@ -28,19 +29,20 @@ func TestRTUOverTCPClientAdvancedUsage(t *testing.T) {
 	handler.Timeout = 5 * time.Second
 	handler.SlaveID = 1
 	handler.Logger = log.Default()
-	handler.Connect()
+	ctx := context.Background()
+	handler.Connect(ctx)
 	defer handler.Close()
 
 	client := modbus.NewClient(handler)
-	results, err := client.ReadDiscreteInputs(15, 2)
+	results, err := client.ReadDiscreteInputs(ctx, 15, 2)
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}
-	results, err = client.WriteMultipleRegisters(1, 2, []byte{0, 3, 0, 4})
+	results, err = client.WriteMultipleRegisters(ctx, 1, 2, []byte{0, 3, 0, 4})
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}
-	results, err = client.WriteMultipleCoils(5, 10, []byte{4, 3})
+	results, err = client.WriteMultipleCoils(ctx, 5, 10, []byte{4, 3})
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}

--- a/test/rtuclient_test.go
+++ b/test/rtuclient_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"context"
 	"log"
 	"testing"
 
@@ -30,18 +31,19 @@ func TestRTUClientAdvancedUsage(t *testing.T) {
 	handler.StopBits = 1
 	handler.SlaveID = 11
 	handler.Logger = log.Default()
-	err := handler.Connect()
+	ctx := context.Background()
+	err := handler.Connect(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer handler.Close()
 
 	client := modbus.NewClient(handler)
-	results, err := client.ReadDiscreteInputs(15, 2)
+	results, err := client.ReadDiscreteInputs(ctx, 15, 2)
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}
-	results, err = client.ReadWriteMultipleRegisters(0, 2, 2, 2, []byte{1, 2, 3, 4})
+	results, err = client.ReadWriteMultipleRegisters(ctx, 0, 2, 2, 2, []byte{1, 2, 3, 4})
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}

--- a/test/tcpclient_test.go
+++ b/test/tcpclient_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"context"
 	"log"
 	"testing"
 	"time"
@@ -26,19 +27,20 @@ func TestTCPClientAdvancedUsage(t *testing.T) {
 	handler.Timeout = 5 * time.Second
 	handler.SlaveID = 1
 	handler.Logger = log.Default()
-	handler.Connect()
+	ctx := context.Background()
+	handler.Connect(ctx)
 	defer handler.Close()
 
 	client := modbus.NewClient(handler)
-	results, err := client.ReadDiscreteInputs(15, 2)
+	results, err := client.ReadDiscreteInputs(ctx, 15, 2)
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}
-	results, err = client.WriteMultipleRegisters(1, 2, []byte{0, 3, 0, 4})
+	results, err = client.WriteMultipleRegisters(ctx, 1, 2, []byte{0, 3, 0, 4})
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}
-	results, err = client.WriteMultipleCoils(5, 10, []byte{4, 3})
+	results, err = client.WriteMultipleCoils(ctx, 5, 10, []byte{4, 3})
 	if err != nil || results == nil {
 		t.Fatal(err, results)
 	}


### PR DESCRIPTION
This PR implements contexts across the project to allow canceling in-flight modbus requests.

BREAKING CHANGE: Various methods now accept `context.Context` as their first argument.