### PR TITLE
fix: Update .goreleaser.yaml to v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - main: ./cmd/modbus-cli
     env:
@@ -26,11 +27,11 @@ archives:
       {{- else }}{{ .Os }}{{ end }}_{{ .Arch }}
     format_overrides:
     - goos: windows
-      format: zip
+      formats: [ 'zip' ]
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Bumps the version of `.goreleaser.yaml` to v2 and fixes deprecations:

- DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
- DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info