### PR TITLE
feat: update ReadDeviceIdentification to return a map

### DIFF
--- a/api.go
+++ b/api.go
@@ -55,7 +55,7 @@ type Client interface {
 	// ReadDeviceIdentification reads the device identification objects using Modbus Function Code 0x2B (MEI type 0x0E).
 	// It supports Basic, Regular, and Extended identification requests, including handling multi-part responses via
 	// the "More Follows" field and iteratively fetching objects until all are received.
-	ReadDeviceIdentification(ctx context.Context, readDeviceIDCode ReadDeviceIDCode) (results [][]byte, err error)
+	ReadDeviceIdentification(ctx context.Context, readDeviceIDCode ReadDeviceIDCode) (results map[byte][]byte, err error)
 	// ReadDeviceIdentification behaves like ReadDeviceIdentification but with an Object ID offset
-	ReadDeviceIdentificationWithObjectIDOffset(ctx context.Context, readDeviceIDCode ReadDeviceIDCode, objectIDOffset int) (results [][]byte, err error)
+	ReadDeviceIdentificationWithObjectIDOffset(ctx context.Context, readDeviceIDCode ReadDeviceIDCode, objectIDOffset int) (results map[byte][]byte, err error)
 }

--- a/cmd/modbus-cli/main.go
+++ b/cmd/modbus-cli/main.go
@@ -128,10 +128,7 @@ func main() {
 	var res string
 	switch *fnCode {
 	case modbus.FuncCodeReadDeviceIdentification:
-		results := bytes.Split(result, []byte{'\n'})
-		for i, result := range results {
-			res += fmt.Sprintf("ObjectID[%d]: %s\n", i, string(result))
-		}
+		res = string(result)
 	default:
 		switch *pType {
 		case "raw":
@@ -211,7 +208,9 @@ func exec(
 		if err != nil {
 			return nil, err
 		}
-		result = bytes.Join(objects, []byte("\n"))
+		for key, val := range objects {
+			result = append(result, []byte(fmt.Sprintf("Object ID %d = %s\n", key, val))...)
+		}
 	default:
 		err = fmt.Errorf("function code %d is unsupported", fnCode)
 	}


### PR DESCRIPTION
This is required as we need the object ID to object value mapping.