### PR TITLE
fix(modbuscli): handle unsupported conversion types

### DIFF
--- a/cmd/modbus-cli/main.go
+++ b/cmd/modbus-cli/main.go
@@ -275,6 +275,8 @@ func convertToBytes(eType string, order binary.ByteOrder, forcedOrder string, va
 		buf = w.ToFloat32(float32(val))
 	case "float64":
 		buf = w.ToFloat64(float64(val))
+	default:
+		err = fmt.Errorf("unsupported conversion type %s", eType)
 	}
 
 	// flip bytes when CDAB or BADC are used (and we have 4 bytes)


### PR DESCRIPTION
This resolves a bug where providing an unknown value to `-type-exec`, lead to the [if err != nil ](https://github.com/grid-x/modbus/blob/f7cc8b80d85cc57cc3b7fbe77bb46fcc8cac9055/cmd/modbus-cli/main.go#L198) check be skipped, and the program proceeds to call `WriteMultipleRegisters` and fail with an unclear `err = fmt.Errorf("modbus: quantity '%v' must be between '%v' and '%v',", quantity, 1, 123)`