### PR TITLE
Revert "TCP improve protocol deadline checks"

### DIFF
--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -165,7 +165,7 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 	}()
 	handler := NewTCPClientHandler(ln.Addr().String())
 	handler.Timeout = 1 * time.Second
-	handler.ProtocolRecoveryTimeout = 500 * time.Millisecond
+	handler.ProtocolRecoveryTimeout = 50 * time.Millisecond
 	ctx := context.Background()
 	client := NewClient(handler)
 	_, err = client.ReadInputRegisters(ctx, 0, 1)


### PR DESCRIPTION
Reverts grid-x/modbus#116

We released this feature to production and noticed a panic.

From our analysis: 
`processResponse` can return the error `ErrTCPHeaderLength` and this won't be caught in the if 
`if err == io.EOF || err == io.ErrUnexpectedEOF || err == syscall.ECONNRESET { ... }` 
leading to call `err = verify(aduRequest, aduResponse)` with an empty `aduResponse` byte array. 
This then calls `responseVal := binary.BigEndian.Uint16(aduResponse)` which leads to the panic. 

Stack trace:
```
2025-11-20 11:48:56.037 github.com/grid-x/modbus.(*tcpTransporter).readResponse(0x38be408, {0x35e6ef0, 0xc, 0xc}, {0x346fe60, 0x104, 0x104}, {0xc23fda65c1c048e3, 0xc3b544bfe, 0x1b2fa60}, ...)
2025-11-20 11:48:56.037	/app/vendor/github.com/grid-x/modbus/tcpclient.go:373 +0x264
2025-11-20 11:48:56.037	github.com/grid-x/modbus.verify({0x35e6ef0, 0xc, 0xc}, {0x0, 0x0, 0x0})
2025-11-20 11:48:56.037	/usr/local/go/src/encoding/binary/binary.go:156
2025-11-20 11:48:56.036	encoding/binary.bigEndian.Uint16(...)
2025-11-20 11:48:56.036	goroutine 883 [running]:
2025-11-20 11:48:56.034 panic: runtime error: index out of range [1] with length 0
```