### PR TITLE
Closing connection on any error

### DIFF
--- a/cmd/modbus-cli/main.go
+++ b/cmd/modbus-cli/main.go
@@ -126,7 +126,7 @@ func main() {
 
 	result, err := exec(ctx, client, eo, *writeParseOrder, *register, *fnCode, *writeValue, *eType, *quantity, *readDeviceIDCode, *readDeviceIDObject)
 	if err != nil && strings.Contains(err.Error(), "crc") && *ignoreCRCError {
-		logger.Info("ignoring crc error: %+v\n", err)
+		logger.Info("ignoring crc error: %+v\n", "error", err)
 	} else if err != nil {
 		logger.Error(err.Error())
 		os.Exit(-1)

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -263,7 +263,10 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 		}
 		switch res {
 		case readResultDone:
-			if err == nil {
+			if err != nil {
+				mb.logf("modbus: read response error: closing connection: %v, res: %v", err, res)
+				mb.close()
+			} else {
 				mb.lastSuccessfulTransactionID = binary.BigEndian.Uint16(aduResponse)
 			}
 			return

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -267,8 +268,16 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 		switch res {
 		case readResultDone:
 			if err != nil {
-				mb.logf("modbus: read response error: closing connection: %v, res: %v", err, res)
-				mb.close()
+				var netErr net.Error
+				if errors.As(err, &netErr) && netErr.Timeout() {
+					// Timeout: the device may be slow. Keep the connection open so
+					// the late response can be drained on the next Send via
+					// ProtocolRecoveryTimeout transaction-ID matching.
+					mb.logf("modbus: read response timeout, keeping connection: %v", err)
+				} else {
+					mb.logf("modbus: read response error: closing connection: %v", err)
+					mb.close()
+				}
 				err = fmt.Errorf("modbus: read response: %w", err)
 			} else {
 				mb.lastSuccessfulTransactionID = binary.BigEndian.Uint16(aduResponse)

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -234,12 +233,25 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 		// Send data
 		mb.logf("modbus: send % x", aduRequest)
 		if _, err = mb.conn.Write(aduRequest); err != nil {
-			if errors.Is(err, syscall.EPIPE) {
-				// If a "broken pipe" (EPIPE) error occurs, it means the remote side has closed the connection.
-				// In this case, we close our side of the connection as well, so that the next attempt will establish a new connection,
-				// because [mb.connect] only dials if [mb.conn] is nil
-				mb.close()
-			}
+			// Close on any write error, regardless of its type. [net.Conn.Write]
+			// has no context parameter, so every error it returns is an OS- or
+			// network-level condition:
+			//
+			//   - EPIPE / ECONNRESET – peer closed the connection.
+			//   - Timeout (net.Error.Timeout) – deadline expired mid-write; TCP
+			//     may have flushed 0..N bytes. The server received a partial
+			//     request and the stream is desynchronized.
+			//   - Any other error (ENETDOWN, EHOSTUNREACH, partial write, …) –
+			//     the connection state is equally unknown.
+			//
+			// For a request/response protocol like Modbus there is no
+			// recoverable write error: either the server got nothing (broken
+			// pipe) or it got a partial frame (stream corruption). In both cases
+			// the only safe action is to close and reconnect, so that the next
+			// Send() dials fresh via connect() (which is a no-op when
+			// mb.conn != nil).
+			mb.logf("modbus: write error, closing connection: %v", err)
+			mb.close()
 			return
 		}
 

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -216,6 +216,7 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 	for {
 		// Establish a new connection if not connected
 		if err = mb.connect(ctx); err != nil {
+			err = fmt.Errorf("modbus: connect: %w", err)
 			return
 		}
 
@@ -226,6 +227,7 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 		// Set write and read timeout
 		if mb.Timeout > 0 {
 			if err = mb.conn.SetDeadline(mb.lastActivity.Add(mb.Timeout)); err != nil {
+				err = fmt.Errorf("modbus: set deadline: %w", err)
 				return
 			}
 		}
@@ -252,6 +254,7 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 			// mb.conn != nil).
 			mb.logf("modbus: write error, closing connection: %v", err)
 			mb.close()
+			err = fmt.Errorf("modbus: write: %w", err)
 			return
 		}
 
@@ -266,6 +269,7 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 			if err != nil {
 				mb.logf("modbus: read response error: closing connection: %v, res: %v", err, res)
 				mb.close()
+				err = fmt.Errorf("modbus: read response: %w", err)
 			} else {
 				mb.lastSuccessfulTransactionID = binary.BigEndian.Uint16(aduResponse)
 			}

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -270,13 +270,12 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 
 	// first two attempts should timeout
 	_, err = client.ReadInputRegisters(ctx, 0, 1)
-	opError, ok := err.(*net.OpError)
-	if !ok || !opError.Timeout() {
+	var opError *net.OpError
+	if !errors.As(err, &opError) || !opError.Timeout() {
 		t.Fatalf("expected timeout error, got %q", err)
 	}
 	_, err = client.ReadInputRegisters(ctx, 0, 1)
-	opError, ok = err.(*net.OpError)
-	if !ok || !opError.Timeout() {
+	if !errors.As(err, &opError) || !opError.Timeout() {
 		t.Fatalf("expected timeout error, got %q", err)
 	}
 

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -112,6 +112,18 @@ type failWriteConn struct{ net.Conn }
 
 func (c *failWriteConn) Write(_ []byte) (int, error) { return 0, io.ErrClosedPipe }
 
+// failReadConn wraps a [net.Conn] so that every Read call fails with the given
+// error and every Write call succeeds (data is discarded). SetDeadline and all
+// other methods delegate to the underlying Conn so that connection-setup code
+// works normally; only Read is intercepted.
+type failReadConn struct {
+	net.Conn
+	readErr error
+}
+
+func (c *failReadConn) Read(_ []byte) (int, error)  { return 0, c.readErr }
+func (c *failReadConn) Write(b []byte) (int, error) { return len(b), nil }
+
 // TestTCPWriteErrorClosesConnection any write error must set
 // mb.conn to nil so that the next Send() dials a fresh connection rather than
 // reusing a dead socket.
@@ -144,6 +156,44 @@ func TestTCPWriteErrorClosesConnection(t *testing.T) {
 	// via connect() rather than writing on a dead socket.
 	if conn := getConn(); conn != nil {
 		t.Fatalf("conn must be nil after write error, got %v", conn)
+	}
+	if dialCalls != 1 {
+		t.Fatalf("expected exactly 1 dial, got %d", dialCalls)
+	}
+}
+
+// TestTCPReadErrorClosesConnection verifies that a fatal read error (readResultDone
+// with err != nil) sets mb.conn to nil so the next Send() dials a fresh
+// connection rather than reusing a socket with an unknown receive-buffer state.
+func TestTCPReadErrorClosesConnection(t *testing.T) {
+	_, cliConn := net.Pipe()
+	t.Cleanup(func() { cliConn.Close() })
+
+	dialCalls := 0
+	handler := NewTCPClientHandler("irrelevant", WithDialer(
+		func(_ context.Context, _, _ string) (net.Conn, error) {
+			dialCalls++
+			return &failReadConn{Conn: cliConn, readErr: io.ErrClosedPipe}, nil
+		},
+	))
+	handler.Timeout = time.Second
+	tr := &handler.tcpTransporter
+
+	getConn := func() net.Conn {
+		tr.mu.Lock()
+		defer tr.mu.Unlock()
+		return tr.conn
+	}
+
+	req := []byte{0, 1, 0, 0, 0, 2, 0, 3} // TID=1, PID=0, Len=2, Unit=0, FC=3
+	if _, err := tr.Send(context.Background(), req); err == nil {
+		t.Fatal("expected read error, got nil")
+	}
+
+	// conn must be nil so the next Send() re-dials rather than reading
+	// stale bytes from a socket whose receive buffer is in an unknown state.
+	if conn := getConn(); conn != nil {
+		t.Fatalf("conn must be nil after read error, got %v", conn)
 	}
 	if dialCalls != 1 {
 		t.Fatalf("expected exactly 1 dial, got %d", dialCalls)

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -102,6 +102,54 @@ func TestTCPTransporter(t *testing.T) {
 	}
 }
 
+// failWriteConn wraps a [net.Conn] so that every Write call fails with
+// io.ErrClosedPipe. SetDeadline and all other methods delegate to the
+// underlying Conn so that the transporter's connection-setup code succeeds
+// normally; only Write is intercepted. This lets tests exercise the
+// write-error code path without depending on OS TCP-buffer timing or
+// net.Pipe's synchronous-close behavior.
+type failWriteConn struct{ net.Conn }
+
+func (c *failWriteConn) Write(_ []byte) (int, error) { return 0, io.ErrClosedPipe }
+
+// TestTCPWriteErrorClosesConnection any write error must set
+// mb.conn to nil so that the next Send() dials a fresh connection rather than
+// reusing a dead socket.
+func TestTCPWriteErrorClosesConnection(t *testing.T) {
+	_, cliConn := net.Pipe()
+	t.Cleanup(func() { cliConn.Close() })
+
+	dialCalls := 0
+	handler := NewTCPClientHandler("irrelevant", WithDialer(
+		func(_ context.Context, _, _ string) (net.Conn, error) {
+			dialCalls++
+			return &failWriteConn{cliConn}, nil
+		},
+	))
+	handler.Timeout = time.Second
+	tr := &handler.tcpTransporter
+
+	getConn := func() net.Conn {
+		tr.mu.Lock()
+		defer tr.mu.Unlock()
+		return tr.conn
+	}
+
+	req := []byte{0, 1, 0, 0, 0, 2, 0, 3} // TID=1, PID=0, Len=2, Unit=0, FC=3
+	if _, err := tr.Send(context.Background(), req); err == nil {
+		t.Fatal("expected write error, got nil")
+	}
+
+	// conn must be nil so the next Send() re-dials
+	// via connect() rather than writing on a dead socket.
+	if conn := getConn(); conn != nil {
+		t.Fatalf("conn must be nil after write error, got %v", conn)
+	}
+	if dialCalls != 1 {
+		t.Fatalf("expected exactly 1 dial, got %d", dialCalls)
+	}
+}
+
 func TestErrTCPHeaderLength_Error(t *testing.T) {
 	// should not explode
 	_ = ErrTCPHeaderLength(1000).Error()


### PR DESCRIPTION
This pull request updates the error handling logic in the `tcpclient.go` file for the Modbus TCP client. The main change is to simplify and strengthen the handling of write errors when sending data over the TCP connection: now, the connection is closed on any write error, not just specific ones like `EPIPE`. This ensures the client always recovers cleanly from any corrupted or lost connection state.

**Improved error handling for TCP writes:**

* The `Send` method now closes the TCP connection on any write error, not just `EPIPE`, to ensure the client recovers from all possible connection issues and avoids protocol desynchronization. This change also improves the clarity of comments explaining why this is necessary for a request/response protocol like Modbus.

**Code cleanup:**

* The unused import of the `errors` package was removed from `tcpclient.go`.

Resolves #97