### PR TITLE
Dynamic PTS for test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,28 @@ all: bin/
 
 .PHONY: test
 test:
-	diagslave -m tcp -p 5020 & diagslave -m enc -p 5021 & go test -run TCP -v $(shell glide nv)
-	socat -d -d pty,raw,echo=0 pty,raw,echo=0 & diagslave -m rtu /dev/pts/1 & go test -run RTU -v $(shell glide nv)
-	socat -d -d pty,raw,echo=0 pty,raw,echo=0 & diagslave -m ascii /dev/pts/3 & go test -run ASCII -v $(shell glide nv)
+	@tmpdir=$$(mktemp -d); \
+	cleanup() { pkill -P $$$$; rm -rf $$tmpdir; }; \
+	trap cleanup EXIT INT TERM; \
+	diagslave -m tcp -p 5020 & diagslave -m enc -p 5021 & \
+	go test -run TCP -v .; \
+	pkill -P $$$$
+	@tmpdir=$$(mktemp -d); \
+	cleanup() { pkill -P $$$$; rm -rf $$tmpdir; }; \
+	trap cleanup EXIT INT TERM; \
+	socat -d -d pty,raw,echo=0,link=$$tmpdir/rtu0 pty,raw,echo=0,link=$$tmpdir/rtu1 & \
+	sleep 0.5; \
+	diagslave -m rtu $$tmpdir/rtu1 & \
+	go test -run RTU -v .; \
+	pkill -P $$$$
+	@tmpdir=$$(mktemp -d); \
+	cleanup() { pkill -P $$$$; rm -rf $$tmpdir; }; \
+	trap cleanup EXIT INT TERM; \
+	socat -d -d pty,raw,echo=0,link=$$tmpdir/ascii0 pty,raw,echo=0,link=$$tmpdir/ascii1 & \
+	sleep 0.5; \
+	diagslave -m ascii $$tmpdir/ascii1 & \
+	go test -run ASCII -v .; \
+	pkill -P $$$$
 	go test -v -count=1 github.com/grid-x/modbus/cmd/modbus-cli 
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -10,28 +10,9 @@ all: bin/
 
 .PHONY: test
 test:
-	@tmpdir=$$(mktemp -d); \
-	cleanup() { pkill -P $$$$; rm -rf $$tmpdir; }; \
-	trap cleanup EXIT INT TERM; \
-	diagslave -m tcp -p 5020 & diagslave -m enc -p 5021 & \
-	go test -run TCP -v .; \
-	pkill -P $$$$
-	@tmpdir=$$(mktemp -d); \
-	cleanup() { pkill -P $$$$; rm -rf $$tmpdir; }; \
-	trap cleanup EXIT INT TERM; \
-	socat -d -d pty,raw,echo=0,link=$$tmpdir/rtu0 pty,raw,echo=0,link=$$tmpdir/rtu1 & \
-	sleep 0.5; \
-	diagslave -m rtu $$tmpdir/rtu1 & \
-	go test -run RTU -v .; \
-	pkill -P $$$$
-	@tmpdir=$$(mktemp -d); \
-	cleanup() { pkill -P $$$$; rm -rf $$tmpdir; }; \
-	trap cleanup EXIT INT TERM; \
-	socat -d -d pty,raw,echo=0,link=$$tmpdir/ascii0 pty,raw,echo=0,link=$$tmpdir/ascii1 & \
-	sleep 0.5; \
-	diagslave -m ascii $$tmpdir/ascii1 & \
-	go test -run ASCII -v .; \
-	pkill -P $$$$
+	./scripts/run-test-with-pty.sh tcp TCP
+	./scripts/run-test-with-pty.sh rtu RTU
+	./scripts/run-test-with-pty.sh ascii ASCII
 	go test -v -count=1 github.com/grid-x/modbus/cmd/modbus-cli 
 
 .PHONY: lint

--- a/scripts/run-test-with-pty.sh
+++ b/scripts/run-test-with-pty.sh
@@ -5,9 +5,19 @@ MODE=$1
 TEST_FILTER=$2
 
 tmpdir=$(mktemp -d)
+diagslave_pids=""
+socat_pid=""
 
 cleanup() {
-    pkill -P $$ 2>/dev/null || true
+    # Kill entire process group to catch any child processes
+    if [ -n "$diagslave_pids" ]; then
+        kill $diagslave_pids 2>/dev/null || [ $? -eq 1 ]
+    fi
+    if [ -n "$socat_pid" ]; then
+        kill $socat_pid 2>/dev/null || [ $? -eq 1 ]
+    fi
+    # Fallback: kill any remaining processes in our process group
+    kill -- -$$ 2>/dev/null || [ $? -eq 1 ]
     rm -rf "$tmpdir"
 }
 
@@ -16,19 +26,25 @@ trap cleanup EXIT INT TERM
 case "$MODE" in
     tcp)
         diagslave -m tcp -p 5020 &
+        diagslave_pids="$! $diagslave_pids"
         diagslave -m enc -p 5021 &
+        diagslave_pids="$! $diagslave_pids"
         go test -run "$TEST_FILTER" -v .
         ;;
     rtu)
         socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
+        socat_pid=$!
         sleep 0.5
         diagslave -m rtu "$tmpdir/pty1" &
+        diagslave_pids="$! $diagslave_pids"
         go test -run "$TEST_FILTER" -v .
         ;;
     ascii)
         socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
+        socat_pid=$!
         sleep 0.5
         diagslave -m ascii "$tmpdir/pty1" &
+        diagslave_pids="$! $diagslave_pids"
         go test -run "$TEST_FILTER" -v .
         ;;
     *)

--- a/scripts/run-test-with-pty.sh
+++ b/scripts/run-test-with-pty.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+MODE=$1
+TEST_FILTER=$2
+
+tmpdir=$(mktemp -d)
+
+cleanup() {
+    pkill -P $$ 2>/dev/null || true
+    rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT INT TERM
+
+case "$MODE" in
+    tcp)
+        diagslave -m tcp -p 5020 &
+        diagslave -m enc -p 5021 &
+        go test -run "$TEST_FILTER" -v .
+        ;;
+    rtu)
+        socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
+        sleep 0.5
+        diagslave -m rtu "$tmpdir/pty1" &
+        go test -run "$TEST_FILTER" -v .
+        ;;
+    ascii)
+        socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
+        sleep 0.5
+        diagslave -m ascii "$tmpdir/pty1" &
+        go test -run "$TEST_FILTER" -v .
+        ;;
+    *)
+        echo "Usage: $0 {tcp|rtu|ascii} TEST_FILTER"
+        exit 1
+        ;;
+esac

--- a/scripts/run-test-with-pty.sh
+++ b/scripts/run-test-with-pty.sh
@@ -30,15 +30,29 @@ trap cleanup EXIT INT TERM
 
 wait_for_pty() {
     local pty_path=$1
-    local timeout=5
-    local elapsed=0
+    local max_iterations=100  # 100 * 0.05s = 5s timeout
+    local iteration=0
     while [ ! -e "$pty_path" ]; do
-        if [ "$elapsed" -ge "$timeout" ]; then
+        if [ "$iteration" -ge "$max_iterations" ]; then
             echo "ERROR: Timeout waiting for $pty_path to appear" >&2
             exit 1
         fi
         sleep 0.05
-        elapsed=$((elapsed + 1))
+        iteration=$((iteration + 1))
+    done
+}
+
+wait_for_tcp_port() {
+    local port=$1
+    local max_iterations=100  # 100 * 0.05s = 5s timeout
+    local iteration=0
+    while ! nc -z localhost "$port" 2>/dev/null; do
+        if [ "$iteration" -ge "$max_iterations" ]; then
+            echo "ERROR: Timeout waiting for port $port to be listening" >&2
+            exit 1
+        fi
+        sleep 0.05
+        iteration=$((iteration + 1))
     done
 }
 
@@ -46,8 +60,12 @@ case "$MODE" in
     tcp)
         diagslave -m tcp -p 5020 &
         diagslave_pids="$! $diagslave_pids"
+        wait_for_tcp_port 5020
+
         diagslave -m enc -p 5021 &
         diagslave_pids="$! $diagslave_pids"
+        wait_for_tcp_port 5021
+
         go test -run "$TEST_FILTER" -v .
         ;;
     rtu)
@@ -55,8 +73,10 @@ case "$MODE" in
         socat_pid=$!
         wait_for_pty "$tmpdir/pty0"
         wait_for_pty "$tmpdir/pty1"
+
         diagslave -m rtu "$tmpdir/pty1" &
         diagslave_pids="$! $diagslave_pids"
+
         go test -run "$TEST_FILTER" -v .
         ;;
     ascii)
@@ -64,8 +84,10 @@ case "$MODE" in
         socat_pid=$!
         wait_for_pty "$tmpdir/pty0"
         wait_for_pty "$tmpdir/pty1"
+
         diagslave -m ascii "$tmpdir/pty1" &
         diagslave_pids="$! $diagslave_pids"
+
         go test -run "$TEST_FILTER" -v .
         ;;
 esac

--- a/scripts/run-test-with-pty.sh
+++ b/scripts/run-test-with-pty.sh
@@ -4,6 +4,11 @@ set -e
 MODE=$1
 TEST_FILTER=$2
 
+if [ -z "$MODE" ] || [ "$MODE" != "tcp" -a "$MODE" != "rtu" -a "$MODE" != "ascii" ]; then
+    echo "Usage: $0 {tcp|rtu|ascii} TEST_FILTER"
+    exit 1
+fi
+
 tmpdir=$(mktemp -d)
 diagslave_pids=""
 socat_pid=""
@@ -62,9 +67,5 @@ case "$MODE" in
         diagslave -m ascii "$tmpdir/pty1" &
         diagslave_pids="$! $diagslave_pids"
         go test -run "$TEST_FILTER" -v .
-        ;;
-    *)
-        echo "Usage: $0 {tcp|rtu|ascii} TEST_FILTER"
-        exit 1
         ;;
 esac

--- a/scripts/run-test-with-pty.sh
+++ b/scripts/run-test-with-pty.sh
@@ -9,6 +9,8 @@ if [ -z "$MODE" ] || [ "$MODE" != "tcp" -a "$MODE" != "rtu" -a "$MODE" != "ascii
     exit 1
 fi
 
+echo "Running tests in $MODE mode with filter '$TEST_FILTER'"
+
 tmpdir=$(mktemp -d)
 diagslave_pids=""
 socat_pid=""
@@ -68,24 +70,13 @@ case "$MODE" in
 
         go test -run "$TEST_FILTER" -v .
         ;;
-    rtu)
+    rtu|ascii)
         socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
         socat_pid=$!
         wait_for_pty "$tmpdir/pty0"
         wait_for_pty "$tmpdir/pty1"
 
-        diagslave -m rtu "$tmpdir/pty1" &
-        diagslave_pids="$! $diagslave_pids"
-
-        go test -run "$TEST_FILTER" -v .
-        ;;
-    ascii)
-        socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
-        socat_pid=$!
-        wait_for_pty "$tmpdir/pty0"
-        wait_for_pty "$tmpdir/pty1"
-
-        diagslave -m ascii "$tmpdir/pty1" &
+        diagslave -m "$MODE" "$tmpdir/pty1" &
         diagslave_pids="$! $diagslave_pids"
 
         go test -run "$TEST_FILTER" -v .

--- a/scripts/run-test-with-pty.sh
+++ b/scripts/run-test-with-pty.sh
@@ -23,6 +23,20 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
+wait_for_pty() {
+    local pty_path=$1
+    local timeout=5
+    local elapsed=0
+    while [ ! -e "$pty_path" ]; do
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "ERROR: Timeout waiting for $pty_path to appear" >&2
+            exit 1
+        fi
+        sleep 0.05
+        elapsed=$((elapsed + 1))
+    done
+}
+
 case "$MODE" in
     tcp)
         diagslave -m tcp -p 5020 &
@@ -34,7 +48,8 @@ case "$MODE" in
     rtu)
         socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
         socat_pid=$!
-        sleep 0.5
+        wait_for_pty "$tmpdir/pty0"
+        wait_for_pty "$tmpdir/pty1"
         diagslave -m rtu "$tmpdir/pty1" &
         diagslave_pids="$! $diagslave_pids"
         go test -run "$TEST_FILTER" -v .
@@ -42,7 +57,8 @@ case "$MODE" in
     ascii)
         socat -d -d pty,raw,echo=0,link="$tmpdir/pty0" pty,raw,echo=0,link="$tmpdir/pty1" &
         socat_pid=$!
-        sleep 0.5
+        wait_for_pty "$tmpdir/pty0"
+        wait_for_pty "$tmpdir/pty1"
         diagslave -m ascii "$tmpdir/pty1" &
         diagslave_pids="$! $diagslave_pids"
         go test -run "$TEST_FILTER" -v .


### PR DESCRIPTION
- Remove hard coded path which can break running cli apps (as these apaths are used by terminals). Use tmp based paths instead.
- Ensure these paths are cleaned up after test run (regardless of state)
- `glide` cli is not really necessary with modern go. So that was cleaned up too
- Moved this test into seperate script file

Fixes: #128