### PR TITLE
Stop duplicating requests, close desynchronized connections

### DIFF
--- a/modbus.go
+++ b/modbus.go
@@ -57,9 +57,14 @@ const (
 // Reference) can write. Deciding that needs the byte after the function code,
 // which is past what this predicate looks at.
 //
-// Transport-agnostic on purpose - the function code sits at a different offset in
-// each framing (adu[1] for RTU and ASCII, adu[tcpHeaderSize] for TCP), so each
+// Kept free of framing detail on purpose: the function code sits at a different
+// offset per framing (adu[tcpHeaderSize] for TCP, adu[1] for RTU and ASCII), so a
 // transport extracts it and this decides the policy.
+//
+// Only the TCP transport consults it today. The RTU and ASCII transports still
+// reissue any request verbatim after reconnecting, so the same duplicate-write
+// hazard remains there - tracked separately, and this predicate is placed here so
+// that fix does not need its own copy of the policy.
 func funcCodeRepeatable(fc byte) bool {
 	switch fc {
 	case FuncCodeReadCoils,

--- a/modbus.go
+++ b/modbus.go
@@ -40,6 +40,39 @@ const (
 	FuncCodeReadDeviceIdentification = 43
 )
 
+// funcCodeRepeatable reports whether a request carrying this function code may be
+// written to the wire more than once. Link recovery reissues a request verbatim
+// after reconnecting, which is harmless for a read but means a device that
+// processed a write before the connection dropped executes it again - once per
+// recovery attempt.
+//
+// Only purely reading function codes are repeatable. Everything else counts as a
+// write, including FuncCodeReadWriteMultipleRegisters (which also writes) and any
+// vendor-specific code we cannot reason about: misjudging a read costs one failed
+// request, misjudging a write duplicates a command on live equipment.
+//
+// FuncCodeReadDeviceIdentification is excluded for the same reason. It is
+// Encapsulated Interface Transport, and only MEI type
+// meiTypeReadDeviceIdentification is a read - MEI type 13 (CANopen General
+// Reference) can write. Deciding that needs the byte after the function code,
+// which is past what this predicate looks at.
+//
+// Transport-agnostic on purpose - the function code sits at a different offset in
+// each framing (adu[1] for RTU and ASCII, adu[tcpHeaderSize] for TCP), so each
+// transport extracts it and this decides the policy.
+func funcCodeRepeatable(fc byte) bool {
+	switch fc {
+	case FuncCodeReadCoils,
+		FuncCodeReadDiscreteInputs,
+		FuncCodeReadHoldingRegisters,
+		FuncCodeReadInputRegisters,
+		FuncCodeReadFIFOQueue:
+		return true
+	default:
+		return false
+	}
+}
+
 // meiType specifies a MEI Type as defined in https://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b.pdf#page=44
 type meiType byte
 

--- a/serial.go
+++ b/serial.go
@@ -120,12 +120,12 @@ func (mb *serialPort) reconnect(ctx context.Context, err error, linkRecoveryDead
 	defer retryTicker.Stop()
 
 	for {
-		if cerr := mb.connect(ctx); cerr == nil {
+		cerr := mb.connect(ctx)
+		if cerr == nil {
 			return nil
-		} else {
-			recoveryErr = errors.Join(recoveryErr, cerr)
-			mb.logf("modbus: error reconnecting: %v", cerr)
 		}
+		recoveryErr = errors.Join(recoveryErr, cerr)
+		mb.logf("modbus: error reconnecting: %v", cerr)
 
 		select {
 		case <-ctx.Done():

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -445,14 +445,16 @@ func (mb *tcpTransporter) isLateResponse(got uint16) bool {
 
 func (mb *tcpTransporter) processResponse(data []byte) (aduResponse []byte, err error) {
 	// Read length, ignore transaction & protocol id (4 bytes)
+	// An implausible length means the bytes just read were not a frame header at
+	// all - most likely the tail of an earlier frame. There is nothing to salvage:
+	// the caller marks this as a desync and Send discards the connection, so the
+	// receive buffer goes with it and draining it here would be pointless.
 	length := int(binary.BigEndian.Uint16(data[4:]))
 	if length <= 0 {
-		mb.flush(data[:])
 		err = ErrTCPHeaderLength(length)
 		return
 	}
 	if length > (tcpMaxLength - (tcpHeaderSize - 1)) {
-		mb.flush(data[:])
 		err = ErrTCPHeaderLength(length)
 		return
 	}
@@ -570,22 +572,6 @@ func (mb *tcpTransporter) Close() error {
 	defer mb.mu.Unlock()
 
 	return mb.close()
-}
-
-// flush flushes pending data in the connection,
-// returns io.EOF if connection is closed.
-func (mb *tcpTransporter) flush(b []byte) (err error) {
-	if err = mb.conn.SetReadDeadline(time.Now()); err != nil {
-		return
-	}
-	// Timeout setting will be reset when reading
-	if _, err = mb.conn.Read(b); err != nil {
-		// Ignore timeout error
-		if netError, ok := err.(net.Error); ok && netError.Timeout() {
-			err = nil
-		}
-	}
-	return
 }
 
 func (mb *tcpTransporter) logf(format string, v ...interface{}) {

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -568,6 +568,17 @@ func (mb *tcpTransporter) close() (err error) {
 		err = mb.conn.Close()
 		mb.conn = nil
 	}
+	// Collapse the late-response window. Nothing can still be in flight on a
+	// connection that no longer exists, so no transaction ID may be treated as a
+	// late response until a new exchange succeeds on the next connection.
+	//
+	// Without this the window keeps spanning transactions that only ever existed
+	// on the previous socket, and it widens with every further attempt because
+	// lastAttemptedTransactionID advances while lastSuccessfulTransactionID stays
+	// frozen. A stray frame on a fresh connection would then be taken for a late
+	// response, silently drained, and the resulting clean timeout would keep a
+	// connection this function had just decided to discard.
+	mb.lastSuccessfulTransactionID = mb.lastAttemptedTransactionID
 	return
 }
 

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -336,6 +336,33 @@ func (mb *tcpTransporter) shouldRecover(err error) bool {
 	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET)
 }
 
+// isRepeatable reports whether aduRequest may be written to the wire a second
+// time. Link recovery reissues the request verbatim after reconnecting, which is
+// harmless for a read but means a device that processed a write before dropping
+// the connection executes it again - once per recovery attempt.
+//
+// Only function codes that are purely read are repeatable. Everything else is
+// treated as a write, including FuncCodeReadWriteMultipleRegisters (which also
+// writes) and any vendor-specific code we cannot reason about: the cost of
+// misjudging a read is one failed request, the cost of misjudging a write is a
+// duplicated command on live equipment.
+func isRepeatable(aduRequest []byte) bool {
+	if len(aduRequest) <= tcpHeaderSize {
+		return false
+	}
+	switch aduRequest[tcpHeaderSize] {
+	case FuncCodeReadCoils,
+		FuncCodeReadDiscreteInputs,
+		FuncCodeReadHoldingRegisters,
+		FuncCodeReadInputRegisters,
+		FuncCodeReadFIFOQueue,
+		FuncCodeReadDeviceIdentification:
+		return true
+	default:
+		return false
+	}
+}
+
 func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryDeadline time.Time, protocolDeadline time.Time) (aduResponse []byte, res readResult, err error) {
 	// res is readResultDone by default, which either means we succeeded or err contains the fatal error
 	for {
@@ -351,7 +378,12 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 			if mb.LinkRecoveryTimeout == 0 || time.Until(recoveryDeadline) < 0 {
 				return
 			}
-			if mb.shouldRecover(err) {
+			if mb.shouldRecover(err) && isRepeatable(aduRequest) {
+				// The stream is empty rather than misaligned, and the request is a
+				// read, so reconnecting and reissuing it has no effect on the device.
+				// A write is reported instead - it may already have been executed
+				// before the connection dropped - leaving the retry to the caller,
+				// which re-encodes with a fresh transaction ID.
 				mb.logf("modbus: connection closed by remote side: %v", err)
 				res = readResultCloseRetry
 			}

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -37,6 +37,23 @@ func (length ErrTCPHeaderLength) Error() string {
 		length, tcpMaxLength-tcpHeaderSize+1)
 }
 
+// ErrStreamDesynced reports that the response stream is no longer aligned to a
+// Modbus frame boundary, so the bytes still buffered on the connection cannot be
+// attributed to any request. It is returned wrapped around the underlying cause.
+//
+// A desynchronized connection is not recoverable in place: the transporter
+// closes it so that the next Send dials afresh. Callers that want the request
+// retried must issue it again, which encodes a new transaction ID. The
+// transporter deliberately does not retry by itself — re-writing the same ADU
+// would put a duplicate frame with an identical transaction ID on the wire, and
+// for a write function code that makes the device execute the command twice.
+var ErrStreamDesynced = errors.New("modbus: response stream desynchronized")
+
+// desynced marks err as a stream desynchronization, see [ErrStreamDesynced].
+func desynced(err error) error {
+	return fmt.Errorf("%w: %w", ErrStreamDesynced, err)
+}
+
 // TCPClientHandler implements Packager and Transporter interface.
 type TCPClientHandler struct {
 	tcpPackager
@@ -197,7 +214,6 @@ type readResult int
 
 const (
 	readResultDone readResult = iota
-	readResultRetry
 	readResultCloseRetry
 )
 
@@ -269,10 +285,17 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 		case readResultDone:
 			if err != nil {
 				var netErr net.Error
-				if errors.As(err, &netErr) && netErr.Timeout() {
-					// Timeout: the device may be slow. Keep the connection open so
-					// the late response can be drained on the next Send via
-					// ProtocolRecoveryTimeout transaction-ID matching.
+				if errors.As(err, &netErr) && netErr.Timeout() && !errors.Is(err, ErrStreamDesynced) {
+					// Clean timeout: nothing of the response was consumed, so the
+					// stream is still aligned to a frame boundary and the device may
+					// simply be slow. Keep the connection open so the late response
+					// can be drained on the next Send via ProtocolRecoveryTimeout
+					// transaction-ID matching.
+					//
+					// A timeout that hit *mid-frame* is excluded: it leaves a partial
+					// frame in the receive buffer, so the next Send would parse the
+					// remainder of that frame as a header. Such a connection has to
+					// be closed, see [ErrStreamDesynced].
 					mb.logf("modbus: read response timeout, keeping connection: %v", err)
 				} else {
 					mb.logf("modbus: read response error: closing connection: %v", err)
@@ -283,9 +306,6 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 				mb.lastSuccessfulTransactionID = binary.BigEndian.Uint16(aduResponse)
 			}
 			return
-		case readResultRetry:
-			mb.logf("modbus: retry reading response, because of %v", err)
-			continue
 		case readResultCloseRetry:
 			mb.logf("modbus: close connection and retry reading response, because of %v", err)
 			mb.close()
@@ -306,16 +326,27 @@ func (mb *tcpTransporter) shouldRecover(err error) bool {
 	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET)
 }
 
-
 func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryDeadline time.Time, protocolDeadline time.Time) (aduResponse []byte, res readResult, err error) {
 	// res is readResultDone by default, which either means we succeeded or err contains the fatal error
 	for {
-		if _, err = io.ReadFull(mb.conn, data[:tcpHeaderSize]); err != nil {
+		var n int
+		if n, err = io.ReadFull(mb.conn, data[:tcpHeaderSize]); err != nil {
+			if n > 0 {
+				// A partial header was consumed, so the remaining bytes of that
+				// frame are still queued and the stream is misaligned. Neither
+				// reading again nor resending the request recovers it; report so
+				// that Send closes the connection. See [ErrStreamDesynced].
+				err = desynced(err)
+				return
+			}
 			// recovery disabled or deadline reached - report error
 			if mb.LinkRecoveryTimeout == 0 || time.Until(recoveryDeadline) < 0 {
 				return
 			}
 			if mb.shouldRecover(err) {
+				// Nothing of the frame was consumed, so the remote side closed
+				// before answering at all. Reconnecting and reissuing the request is
+				// safe here: the stream is empty rather than misaligned.
 				mb.logf("modbus: connection closed by remote side: %v", err)
 				res = readResultCloseRetry
 			}
@@ -323,50 +354,56 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 		}
 		aduResponse, err = mb.processResponse(data[:]) // this also does io
 		if err != nil {
-			// recovery disabled or deadline reached - report error
-			if mb.LinkRecoveryTimeout == 0 || time.Until(recoveryDeadline) < 0 {
-				return
-			}
-			if mb.shouldRecover(err) {
-				mb.logf("modbus: connection closed by remote side: %v", err)
-				res = readResultCloseRetry
-				return
-			}
-			if _, ok := err.(ErrTCPHeaderLength); ok {
-				// TCP header not OK - retry with another query
-				res = readResultRetry
-				return
-			}
-			// other error - report
+			// The header was consumed in full, so any failure past this point
+			// leaves the stream mid-frame - whether the announced length was
+			// nonsense (which means the "header" was really the tail of an earlier
+			// frame) or the body read failed part-way through.
+			err = desynced(err)
 			return
 		}
 
 		err = verify(aduRequest, aduResponse)
 		if err != nil {
 			mb.logf("modbus: verify error: %v", err)
-			// recovery disabled or deadline reached - report error
-			if mb.ProtocolRecoveryTimeout == 0 || time.Until(protocolDeadline) < 0 {
-				return
+
+			var mismatch errTransactionIDMismatch
+			if errors.As(err, &mismatch) && mb.ProtocolRecoveryTimeout > 0 &&
+				time.Until(protocolDeadline) >= 0 && mb.isLateResponse(mismatch.got) {
+				// This is the (late) response to an earlier query that already timed
+				// out. The frame boundary is intact, so discard it and keep reading:
+				// the response we are waiting for should follow *without* sending
+				// another query. (If we sent another query with transaction ID X+1
+				// here, we would again get a mismatch for the response to X already
+				// sitting in the buffer.)
+				continue
 			}
-			if v, ok := err.(errTransactionIDMismatch); ok {
-				if (v.got > mb.lastSuccessfulTransactionID && v.got < mb.lastAttemptedTransactionID) ||
-					(mb.lastAttemptedTransactionID < mb.lastSuccessfulTransactionID && (v.got > mb.lastSuccessfulTransactionID || v.got < mb.lastAttemptedTransactionID)) {
-					// most likely, we simply had a timeout for the earlier query and now read the (late) response. Ignore it
-					// and assume that the response will come *without* sending another query. (If we send another query
-					// with transactionId X+1 here, we would again get a transactionMismatchError if the response to
-					// transactionId X is already in the buffer).
-					continue
-				}
-				res = readResultRetry
-				return
-			}
-			// other error - report
+
+			// The response cannot be attributed to the request we sent, and it is
+			// not a late response we can account for. Report it as a desync so that
+			// Send closes the connection: resending the same ADU would put a
+			// duplicate frame with an identical transaction ID on the wire. Retrying
+			// is the caller's decision, and it re-encodes with a fresh transaction
+			// ID. See [ErrStreamDesynced].
+			err = desynced(err)
 			return
 		}
 		mb.logf("modbus: recv % x\n", aduResponse)
 		return // everything is OK
 
 	}
+}
+
+// isLateResponse reports whether got identifies the response to an earlier
+// request that we already gave up on, i.e. whether it lies strictly between the
+// last successfully verified and the currently attempted transaction ID, taking
+// uint16 wraparound into account.
+func (mb *tcpTransporter) isLateResponse(got uint16) bool {
+	if mb.lastAttemptedTransactionID < mb.lastSuccessfulTransactionID {
+		// The counter wrapped between the two, so the open interval is the union
+		// of the two ends of the uint16 range.
+		return got > mb.lastSuccessfulTransactionID || got < mb.lastAttemptedTransactionID
+	}
+	return got > mb.lastSuccessfulTransactionID && got < mb.lastAttemptedTransactionID
 }
 
 func (mb *tcpTransporter) processResponse(data []byte) (aduResponse []byte, err error) {

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -220,14 +220,6 @@ type tcpTransporter struct {
 	tlsConfig *tls.Config
 }
 
-// helper value to signify what to do in Send
-type readResult int
-
-const (
-	readResultDone readResult = iota
-	readResultCloseRetry
-)
-
 // Send sends data to server and ensures response length is greater than header length.
 func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduResponse []byte, err error) {
 	mb.mu.Lock()
@@ -260,6 +252,13 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 			}
 		}
 
+		// Recorded before the write, not after: close() collapses the late-response
+		// window onto this value, and on a write error it must name the request we
+		// are attempting rather than the previous one - otherwise the window still
+		// spans this transaction and a frame carrying its ID would be drained as a
+		// late response on the next connection.
+		mb.lastAttemptedTransactionID = binary.BigEndian.Uint16(aduRequest)
+
 		// Send data
 		mb.logf("modbus: send % x", aduRequest)
 		if _, err = mb.conn.Write(aduRequest); err != nil {
@@ -286,37 +285,13 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 			return
 		}
 
-		mb.lastAttemptedTransactionID = binary.BigEndian.Uint16(aduRequest)
-		var res readResult
-		aduResponse, res, err = mb.readResponse(aduRequest, data[:], linkRecoveryDeadline, protocolRecoveryDeadline)
+		var reconnectAndReissue bool
+		aduResponse, reconnectAndReissue, err = mb.readResponse(aduRequest, data[:], linkRecoveryDeadline, protocolRecoveryDeadline)
 		if err != nil {
-			mb.logf("modbus: read response error: %v, res: %v", err, res)
+			mb.logf("modbus: read response error: %v, reconnect: %v", err, reconnectAndReissue)
 		}
-		switch res {
-		case readResultDone:
-			if err != nil {
-				var netErr net.Error
-				if errors.As(err, &netErr) && netErr.Timeout() && !errors.Is(err, ErrStreamDesynced) {
-					// Clean timeout: nothing of the response was consumed, so the
-					// stream is still aligned to a frame boundary and the device may
-					// simply be slow. Keep the connection open so the late response
-					// can be drained on the next Send via ProtocolRecoveryTimeout
-					// transaction-ID matching.
-					//
-					// A [ErrStreamDesynced] is excluded: it leaves a partial
-					// frame in the receive buffer. Such a connection has to
-					// be closed.
-					mb.logf("modbus: read response timeout, keeping connection: %v", err)
-				} else {
-					mb.logf("modbus: read response error: closing connection: %v", err)
-					mb.close()
-				}
-				err = fmt.Errorf("modbus: read response: %w", err)
-			} else {
-				mb.lastSuccessfulTransactionID = binary.BigEndian.Uint16(aduResponse)
-			}
-			return
-		case readResultCloseRetry:
+
+		if reconnectAndReissue {
 			mb.logf("modbus: close connection and retry reading response, because of %v", err)
 			mb.close()
 			select {
@@ -325,10 +300,30 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 			default:
 				continue
 			}
-		default:
-			mb.logf("modbus: unhandled read result %v", res)
-			return nil, fmt.Errorf("modbus: unhandled read result %v", res)
 		}
+
+		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() && !errors.Is(err, ErrStreamDesynced) {
+				// Clean timeout: nothing of the response was consumed, so the
+				// stream is still aligned to a frame boundary and the device may
+				// simply be slow. Keep the connection open so the late response
+				// can be drained on the next Send via ProtocolRecoveryTimeout
+				// transaction-ID matching.
+				//
+				// A desync leaves a partial frame queued, so that connection
+				// cannot be kept - see [ErrStreamDesynced].
+				mb.logf("modbus: read response timeout, keeping connection: %v", err)
+			} else {
+				mb.logf("modbus: read response error: closing connection: %v", err)
+				mb.close()
+			}
+			err = fmt.Errorf("modbus: read response: %w", err)
+			return
+		}
+
+		mb.lastSuccessfulTransactionID = binary.BigEndian.Uint16(aduResponse)
+		return
 	}
 }
 
@@ -337,40 +332,32 @@ func (mb *tcpTransporter) shouldRecover(err error) bool {
 }
 
 // isRepeatable reports whether aduRequest may be written to the wire a second
-// time. Link recovery reissues the request verbatim after reconnecting, which is
-// harmless for a read but means a device that processed a write before dropping
-// the connection executes it again - once per recovery attempt.
-//
-// Only function codes that are purely read are repeatable. Everything else is
-// treated as a write, including FuncCodeReadWriteMultipleRegisters (which also
-// writes) and any vendor-specific code we cannot reason about: the cost of
-// misjudging a read is one failed request, the cost of misjudging a write is a
-// duplicated command on live equipment.
+// time, i.e. whether reissuing it during link recovery is free of side effects on
+// the device. The policy lives in funcCodeRepeatable; this only knows where MBAP
+// keeps the function code.
 func isRepeatable(aduRequest []byte) bool {
 	if len(aduRequest) <= tcpHeaderSize {
 		return false
 	}
-	switch aduRequest[tcpHeaderSize] {
-	case FuncCodeReadCoils,
-		FuncCodeReadDiscreteInputs,
-		FuncCodeReadHoldingRegisters,
-		FuncCodeReadInputRegisters,
-		FuncCodeReadFIFOQueue,
-		FuncCodeReadDeviceIdentification:
-		return true
-	default:
-		return false
-	}
+	return funcCodeRepeatable(aduRequest[tcpHeaderSize])
 }
 
-func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryDeadline time.Time, protocolDeadline time.Time) (aduResponse []byte, res readResult, err error) {
-	// res is readResultDone by default, which either means we succeeded or err contains the fatal error
+// readResponse reads one response frame. It returns reconnectAndReissue when the
+// caller should drop the connection, redial and write the request again - only
+// ever for a request that is safe to repeat, see [funcCodeRepeatable]. Otherwise
+// err is nil on success, or holds the failure to report.
+func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryDeadline time.Time, protocolDeadline time.Time) (aduResponse []byte, reconnectAndReissue bool, err error) {
 	for {
 		var n int
 		if n, err = io.ReadFull(mb.conn, data[:tcpHeaderSize]); err != nil {
-			if n > 0 {
-				// A partial header was consumed, so the remaining bytes of that
-				// frame are still queued and the stream is misaligned.
+			if n > 0 && !mb.shouldRecover(err) {
+				// A partial header was consumed and the connection is still up, so
+				// the rest of that frame is queued and the stream is misaligned.
+				//
+				// Errors shouldRecover covers are excluded deliberately: there the
+				// socket is gone, so nothing is left queued to misalign us and the
+				// recovery path below can reconnect. That path decides for itself
+				// whether reissuing the request is safe.
 				err = desynced(err)
 				return
 			}
@@ -385,7 +372,7 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 				// before the connection dropped - leaving the retry to the caller,
 				// which re-encodes with a fresh transaction ID.
 				mb.logf("modbus: connection closed by remote side: %v", err)
-				res = readResultCloseRetry
+				reconnectAndReissue = true
 			}
 			return
 		}
@@ -415,12 +402,10 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 				continue
 			}
 
-			// A complete frame belonging to neither this request nor an earlier one
-			// we can account for. The bytes are still frame-aligned, but the
-			// request/response pairing is lost: our own request stays outstanding and
-			// its answer would corrupt the next exchange. This is also where a
-			// genuinely misaligned stream ends up, when the tail of an earlier frame
-			// happens to parse as a plausible header. See [ErrStreamDesynced].
+			// Frame-aligned, but our request stays outstanding and this frame
+			// belongs to nothing we can account for. A genuinely misaligned stream
+			// also lands here, when an earlier frame's tail parses as a plausible
+			// header. See [ErrStreamDesynced].
 			err = desynced(err)
 			return
 		}
@@ -588,14 +573,8 @@ func (mb *tcpTransporter) close() (err error) {
 	}
 	// Collapse the late-response window. Nothing can still be in flight on a
 	// connection that no longer exists, so no transaction ID may be treated as a
-	// late response until a new exchange succeeds on the next connection.
-	//
-	// Without this the window keeps spanning transactions that only ever existed
-	// on the previous socket, and it widens with every further attempt because
-	// lastAttemptedTransactionID advances while lastSuccessfulTransactionID stays
-	// frozen. A stray frame on a fresh connection would then be taken for a late
-	// response, silently drained, and the resulting clean timeout would keep a
-	// connection this function had just decided to discard.
+	// late response until a new exchange succeeds on the next connection. See
+	// TestTCPCloseResetsLateResponseWindow for what goes wrong without this.
 	mb.lastSuccessfulTransactionID = mb.lastAttemptedTransactionID
 	return
 }

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -37,19 +37,30 @@ func (length ErrTCPHeaderLength) Error() string {
 		length, tcpMaxLength-tcpHeaderSize+1)
 }
 
-// ErrStreamDesynced reports that the response stream is no longer aligned to a
-// Modbus frame boundary, so the bytes still buffered on the connection cannot be
-// attributed to any request. It is returned wrapped around the underlying cause.
+// ErrStreamDesynced reports that responses on the connection can no longer be
+// paired with the requests that were sent. It is returned wrapped around the
+// underlying cause, and covers two conditions that cannot be told apart from the
+// outside:
 //
-// A desynchronized connection is not recoverable in place: the transporter
-// closes it so that the next Send dials afresh. Callers that want the request
-// retried must issue it again, which encodes a new transaction ID. The
-// transporter deliberately does not retry by itself — re-writing the same ADU
-// would put a duplicate frame with an identical transaction ID on the wire, and
-// for a write function code that makes the device execute the command twice.
-var ErrStreamDesynced = errors.New("modbus: response stream desynchronized")
+//   - The byte stream is misaligned. A read failed part-way through a frame, so
+//     the rest of that frame is still queued and the next read would parse those
+//     leftover bytes as a header.
+//   - A complete, well-formed frame arrived that cannot be attributed to the
+//     request that was sent, and is not a late response that can be accounted
+//     for. Here the bytes are still frame-aligned, but a request is left
+//     outstanding whose answer would corrupt the next exchange, and there is no
+//     way to tell how many such orphans are queued.
+//
+// Neither is recoverable in place: the transporter closes the connection so that
+// the next Send dials afresh. Callers that want the request retried must issue it
+// again, which encodes a new transaction ID. The transporter deliberately does
+// not retry by itself — re-writing the same ADU would put a duplicate frame with
+// an identical transaction ID on the wire, and for a write function code that
+// makes the device execute the command twice.
+var ErrStreamDesynced = errors.New("modbus: response stream out of sync with requests")
 
-// desynced marks err as a stream desynchronization, see [ErrStreamDesynced].
+// desynced marks err as a loss of request/response pairing, see
+// [ErrStreamDesynced].
 func desynced(err error) error {
 	return fmt.Errorf("%w: %w", ErrStreamDesynced, err)
 }
@@ -292,10 +303,9 @@ func (mb *tcpTransporter) Send(ctx context.Context, aduRequest []byte) (aduRespo
 					// can be drained on the next Send via ProtocolRecoveryTimeout
 					// transaction-ID matching.
 					//
-					// A timeout that hit *mid-frame* is excluded: it leaves a partial
-					// frame in the receive buffer, so the next Send would parse the
-					// remainder of that frame as a header. Such a connection has to
-					// be closed, see [ErrStreamDesynced].
+					// A [ErrStreamDesynced] is excluded: it leaves a partial
+					// frame in the receive buffer. Such a connection has to
+					// be closed.
 					mb.logf("modbus: read response timeout, keeping connection: %v", err)
 				} else {
 					mb.logf("modbus: read response error: closing connection: %v", err)
@@ -333,9 +343,7 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 		if n, err = io.ReadFull(mb.conn, data[:tcpHeaderSize]); err != nil {
 			if n > 0 {
 				// A partial header was consumed, so the remaining bytes of that
-				// frame are still queued and the stream is misaligned. Neither
-				// reading again nor resending the request recovers it; report so
-				// that Send closes the connection. See [ErrStreamDesynced].
+				// frame are still queued and the stream is misaligned.
 				err = desynced(err)
 				return
 			}
@@ -344,9 +352,6 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 				return
 			}
 			if mb.shouldRecover(err) {
-				// Nothing of the frame was consumed, so the remote side closed
-				// before answering at all. Reconnecting and reissuing the request is
-				// safe here: the stream is empty rather than misaligned.
 				mb.logf("modbus: connection closed by remote side: %v", err)
 				res = readResultCloseRetry
 			}
@@ -378,12 +383,12 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 				continue
 			}
 
-			// The response cannot be attributed to the request we sent, and it is
-			// not a late response we can account for. Report it as a desync so that
-			// Send closes the connection: resending the same ADU would put a
-			// duplicate frame with an identical transaction ID on the wire. Retrying
-			// is the caller's decision, and it re-encodes with a fresh transaction
-			// ID. See [ErrStreamDesynced].
+			// A complete frame belonging to neither this request nor an earlier one
+			// we can account for. The bytes are still frame-aligned, but the
+			// request/response pairing is lost: our own request stays outstanding and
+			// its answer would corrupt the next exchange. This is also where a
+			// genuinely misaligned stream ends up, when the tail of an earlier frame
+			// happens to parse as a plausible header. See [ErrStreamDesynced].
 			err = desynced(err)
 			return
 		}
@@ -510,7 +515,7 @@ func (mb *tcpTransporter) connect(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(mb.ConnectDelay): //silent period
+		case <-time.After(mb.ConnectDelay): // silent period
 		}
 	}
 	return nil

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -378,10 +378,20 @@ func (mb *tcpTransporter) readResponse(aduRequest []byte, data []byte, recoveryD
 		}
 		aduResponse, err = mb.processResponse(data[:]) // this also does io
 		if err != nil {
-			// The header was consumed in full, so any failure past this point
-			// leaves the stream mid-frame - whether the announced length was
-			// nonsense (which means the "header" was really the tail of an earlier
-			// frame) or the body read failed part-way through.
+			if mb.shouldRecover(err) {
+				// The socket is gone rather than misaligned: nothing of this frame is
+				// left queued, so a fresh connection starts clean. Same situation as
+				// the header read above, and treated the same way.
+				if mb.LinkRecoveryTimeout != 0 && time.Until(recoveryDeadline) >= 0 && isRepeatable(aduRequest) {
+					mb.logf("modbus: connection closed by remote side: %v", err)
+					reconnectAndReissue = true
+				}
+				return
+			}
+			// The announced length was nonsense - so what we read as a header was
+			// really the tail of an earlier frame - or the body read failed some
+			// other way with the connection still up. Either way the stream is
+			// mid-frame and cannot be resynchronised.
 			err = desynced(err)
 			return
 		}

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -334,7 +334,22 @@ func TestTCPMidFrameTimeoutClosesConnection(t *testing.T) {
 
 	done := make(chan struct{})
 	defer close(done)
+	// The server reports over a channel rather than calling t.Error itself:
+	// nothing joins this goroutine before the test returns, and a t.Error after
+	// that point panics the whole run.
+	srvErr := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	t.Cleanup(func() {
+		wg.Wait()
+		select {
+		case err := <-srvErr:
+			t.Errorf("server: %v", err)
+		default:
+		}
+	})
 	go func() {
+		defer wg.Done()
 		conn, err := ln.Accept()
 		if err != nil {
 			return
@@ -343,7 +358,7 @@ func TestTCPMidFrameTimeoutClosesConnection(t *testing.T) {
 		// Write a partial header - 3 of tcpHeaderSize bytes - and then stall, so
 		// that the client's ReadFull consumes those bytes and then times out.
 		if _, err := conn.Write([]byte{0x00, 0x01, 0x00}); err != nil {
-			t.Error(err)
+			srvErr <- err
 			return
 		}
 		// keep the connection open until the main routine is finished
@@ -390,8 +405,22 @@ func TestTCPNoResendOnUnattributableResponse(t *testing.T) {
 	var (
 		mu       sync.Mutex
 		observed []uint16
+		wg       sync.WaitGroup
 	)
+	// See TestTCPMidFrameTimeoutClosesConnection: the server must not touch t
+	// from a goroutine the test does not join.
+	srvErr := make(chan error, 1)
+	wg.Add(1)
+	t.Cleanup(func() {
+		wg.Wait()
+		select {
+		case err := <-srvErr:
+			t.Errorf("server: %v", err)
+		default:
+		}
+	})
 	go func() {
+		defer wg.Done()
 		conn, err := ln.Accept()
 		if err != nil {
 			return
@@ -414,7 +443,7 @@ func TestTCPNoResendOnUnattributableResponse(t *testing.T) {
 				Data:         []byte{0x02, 0xCA, 0xFE},
 			})
 			if err != nil {
-				t.Error(err)
+				srvErr <- err
 				return
 			}
 			if isFirst {

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -68,16 +68,17 @@ func TestTCPTransporter(t *testing.T) {
 	}
 	defer ln.Close()
 
+	report, finish := joinServer(t)
 	go func() {
+		defer finish()
 		conn, err := ln.Accept()
 		if err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		defer conn.Close()
-		_, err = io.Copy(conn, conn)
-		if err != nil {
-			t.Error(err)
+		if _, err = io.Copy(conn, conn); err != nil {
+			report(err)
 			return
 		}
 	}()
@@ -124,6 +125,33 @@ type failReadConn struct {
 
 func (c *failReadConn) Read(_ []byte) (int, error)  { return 0, c.readErr }
 func (c *failReadConn) Write(b []byte) (int, error) { return len(b), nil }
+
+// joinServer wires up reporting and joining for a test server goroutine. The
+// goroutine calls report(err) instead of t.Error and defers finish() as its last
+// act; the test joins it and reports in t.Cleanup, so nothing can touch t after
+// the test function has returned - which would panic the whole run.
+func joinServer(t *testing.T) (report func(error), finish func()) {
+	t.Helper()
+
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	t.Cleanup(func() {
+		wg.Wait()
+		select {
+		case err := <-errCh:
+			t.Errorf("server: %v", err)
+		default:
+		}
+	})
+
+	return func(err error) {
+		select {
+		case errCh <- err: // keep the first, drop the rest
+		default:
+		}
+	}, wg.Done
+}
 
 // currentConn reads the transporter's connection under its mutex.
 func currentConn(tr *tcpTransporter) net.Conn {
@@ -210,11 +238,13 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 
 	done := make(chan struct{})
 	defer close(done)
+	report, finish := joinServer(t)
 	data := []byte{0xCA, 0xFE}
 	go func() {
+		defer finish()
 		conn, err := ln.Accept()
 		if err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		defer conn.Close()
@@ -227,31 +257,31 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 		}
 		data1, err := packager.Encode(pdu)
 		if err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		// encoding same PDU twice will increment the transaction id
 		data2, err := packager.Encode(pdu)
 		if err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		// encoding same PDU twice will increment the transaction id
 		data3, err := packager.Encode(pdu)
 		if err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		if _, err := conn.Write(data1); err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		if _, err := conn.Write(data2); err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		if _, err := conn.Write(data3); err != nil {
-			t.Error(err)
+			report(err)
 			return
 		}
 		// keep the connection open until the main routine is finished
@@ -329,22 +359,9 @@ func TestTCPMidFrameTimeoutClosesConnection(t *testing.T) {
 
 	done := make(chan struct{})
 	defer close(done)
-	// The server reports over a channel rather than calling t.Error itself:
-	// nothing joins this goroutine before the test returns, and a t.Error after
-	// that point panics the whole run.
-	srvErr := make(chan error, 1)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	t.Cleanup(func() {
-		wg.Wait()
-		select {
-		case err := <-srvErr:
-			t.Errorf("server: %v", err)
-		default:
-		}
-	})
+	report, finish := joinServer(t)
 	go func() {
-		defer wg.Done()
+		defer finish()
 		conn, err := ln.Accept()
 		if err != nil {
 			return
@@ -353,7 +370,7 @@ func TestTCPMidFrameTimeoutClosesConnection(t *testing.T) {
 		// Write a partial header - 3 of tcpHeaderSize bytes - and then stall, so
 		// that the client's ReadFull consumes those bytes and then times out.
 		if _, err := conn.Write([]byte{0x00, 0x01, 0x00}); err != nil {
-			srvErr <- err
+			report(err)
 			return
 		}
 		// keep the connection open until the main routine is finished
@@ -394,22 +411,10 @@ func TestTCPNoResendOnUnattributableResponse(t *testing.T) {
 	var (
 		mu       sync.Mutex
 		observed []uint16
-		wg       sync.WaitGroup
 	)
-	// See TestTCPMidFrameTimeoutClosesConnection: the server must not touch t
-	// from a goroutine the test does not join.
-	srvErr := make(chan error, 1)
-	wg.Add(1)
-	t.Cleanup(func() {
-		wg.Wait()
-		select {
-		case err := <-srvErr:
-			t.Errorf("server: %v", err)
-		default:
-		}
-	})
+	report, finish := joinServer(t)
 	go func() {
-		defer wg.Done()
+		defer finish()
 		conn, err := ln.Accept()
 		if err != nil {
 			return
@@ -432,7 +437,7 @@ func TestTCPNoResendOnUnattributableResponse(t *testing.T) {
 				Data:         []byte{0x02, 0xCA, 0xFE},
 			})
 			if err != nil {
-				srvErr <- err
+				report(err)
 				return
 			}
 			if isFirst {

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"net"
 	"slices"
@@ -125,6 +126,13 @@ type failReadConn struct {
 func (c *failReadConn) Read(_ []byte) (int, error)  { return 0, c.readErr }
 func (c *failReadConn) Write(b []byte) (int, error) { return len(b), nil }
 
+// currentConn reads the transporter's connection under its mutex.
+func currentConn(tr *tcpTransporter) net.Conn {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return tr.conn
+}
+
 // TestTCPWriteErrorClosesConnection any write error must set
 // mb.conn to nil so that the next Send() dials a fresh connection rather than
 // reusing a dead socket.
@@ -142,12 +150,6 @@ func TestTCPWriteErrorClosesConnection(t *testing.T) {
 	handler.Timeout = time.Second
 	tr := &handler.tcpTransporter
 
-	getConn := func() net.Conn {
-		tr.mu.Lock()
-		defer tr.mu.Unlock()
-		return tr.conn
-	}
-
 	req := []byte{0, 1, 0, 0, 0, 2, 0, 3} // TID=1, PID=0, Len=2, Unit=0, FC=3
 	if _, err := tr.Send(context.Background(), req); err == nil {
 		t.Fatal("expected write error, got nil")
@@ -155,7 +157,7 @@ func TestTCPWriteErrorClosesConnection(t *testing.T) {
 
 	// conn must be nil so the next Send() re-dials
 	// via connect() rather than writing on a dead socket.
-	if conn := getConn(); conn != nil {
+	if conn := currentConn(tr); conn != nil {
 		t.Fatalf("conn must be nil after write error, got %v", conn)
 	}
 	if dialCalls != 1 {
@@ -163,9 +165,9 @@ func TestTCPWriteErrorClosesConnection(t *testing.T) {
 	}
 }
 
-// TestTCPReadErrorClosesConnection verifies that a fatal read error (readResultDone
-// with err != nil) sets mb.conn to nil so the next Send() dials a fresh
-// connection rather than reusing a socket with an unknown receive-buffer state.
+// TestTCPReadErrorClosesConnection verifies that a fatal read error sets mb.conn
+// to nil so the next Send() dials a fresh connection rather than reusing a socket
+// with an unknown receive-buffer state.
 func TestTCPReadErrorClosesConnection(t *testing.T) {
 	_, cliConn := net.Pipe()
 	t.Cleanup(func() { cliConn.Close() })
@@ -180,12 +182,6 @@ func TestTCPReadErrorClosesConnection(t *testing.T) {
 	handler.Timeout = time.Second
 	tr := &handler.tcpTransporter
 
-	getConn := func() net.Conn {
-		tr.mu.Lock()
-		defer tr.mu.Unlock()
-		return tr.conn
-	}
-
 	req := []byte{0, 1, 0, 0, 0, 2, 0, 3} // TID=1, PID=0, Len=2, Unit=0, FC=3
 	if _, err := tr.Send(context.Background(), req); err == nil {
 		t.Fatal("expected read error, got nil")
@@ -193,7 +189,7 @@ func TestTCPReadErrorClosesConnection(t *testing.T) {
 
 	// conn must be nil so the next Send() re-dials rather than reading
 	// stale bytes from a socket whose receive buffer is in an unknown state.
-	if conn := getConn(); conn != nil {
+	if conn := currentConn(tr); conn != nil {
 		t.Fatalf("conn must be nil after read error, got %v", conn)
 	}
 	if dialCalls != 1 {
@@ -369,17 +365,11 @@ func TestTCPMidFrameTimeoutClosesConnection(t *testing.T) {
 	handler.Timeout = 200 * time.Millisecond
 	tr := &handler.tcpTransporter
 
-	getConn := func() net.Conn {
-		tr.mu.Lock()
-		defer tr.mu.Unlock()
-		return tr.conn
-	}
-
 	_, err = NewClient(handler).ReadInputRegisters(context.Background(), 0, 1)
 	if !errors.Is(err, ErrStreamDesynced) {
 		t.Fatalf("expected error wrapping %v, got %q", ErrStreamDesynced, err)
 	}
-	if conn := getConn(); conn != nil {
+	if conn := currentConn(tr); conn != nil {
 		t.Fatalf("conn must be nil after a mid-frame timeout, got %v", conn)
 	}
 }
@@ -480,11 +470,14 @@ func TestTCPNoResendOnUnattributableResponse(t *testing.T) {
 	}
 }
 
-// countRequestsUntilClientGivesUp accepts connections on ln and records the
-// function code of every request it reads, dropping each connection immediately
-// without answering so that the client's link recovery engages. It returns a stop
-// function that waits for the server goroutine and yields the recorded codes.
-func countRequestsUntilClientGivesUp(t *testing.T, ln net.Listener) func() []byte {
+// countRequests accepts connections on ln and records the function code of every
+// request it reads. The first dropAfter connections are closed without answering,
+// so the client's link recovery engages; any connection after that is answered so
+// the client stops instead of spinning until its recovery budget expires.
+//
+// It registers its own cleanup, so a t.Fatal in the caller cannot leak the
+// listener or the accept goroutine, and returns the codes observed so far.
+func countRequests(t *testing.T, ln net.Listener, dropAfter int) func() []byte {
 	t.Helper()
 
 	var (
@@ -505,15 +498,25 @@ func countRequestsUntilClientGivesUp(t *testing.T, ln net.Listener) func() []byt
 			if _, err := io.ReadFull(conn, req); err == nil {
 				mu.Lock()
 				codes = append(codes, req[tcpHeaderSize])
+				answer := len(codes) > dropAfter
 				mu.Unlock()
+				if answer {
+					// Any well-formed frame will do: the client only has to stop
+					// reconnecting. An exception response is the shortest one.
+					resp := []byte{req[0], req[1], 0, 0, 0, 3, req[6], req[tcpHeaderSize] | 0x80, ExceptionCodeIllegalDataAddress}
+					_, _ = conn.Write(resp)
+				}
 			}
-			conn.Close() // drop without answering
+			conn.Close()
 		}
 	}()
 
-	return func() []byte {
+	t.Cleanup(func() {
 		ln.Close()
 		wg.Wait()
+	})
+
+	return func() []byte {
 		mu.Lock()
 		defer mu.Unlock()
 		return append([]byte{}, codes...)
@@ -529,7 +532,7 @@ func TestTCPLinkRecoveryDoesNotReissueWrites(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stop := countRequestsUntilClientGivesUp(t, ln)
+	observed := countRequests(t, ln, math.MaxInt)
 
 	handler := NewTCPClientHandler(ln.Addr().String())
 	handler.Timeout = 500 * time.Millisecond
@@ -540,7 +543,7 @@ func TestTCPLinkRecoveryDoesNotReissueWrites(t *testing.T) {
 	}
 	handler.Close()
 
-	if codes := stop(); len(codes) != 1 {
+	if codes := observed(); len(codes) != 1 {
 		t.Errorf("a write must reach the device at most once, got %d attempts: %v", len(codes), codes)
 	}
 }
@@ -553,18 +556,21 @@ func TestTCPLinkRecoveryReissuesReads(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stop := countRequestsUntilClientGivesUp(t, ln)
+	// Drop only the first connection: the reissued read is then answered, so the
+	// client stops after two attempts instead of churning thousands of sockets
+	// until the recovery budget expires.
+	observed := countRequests(t, ln, 1)
 
 	handler := NewTCPClientHandler(ln.Addr().String())
 	handler.Timeout = 500 * time.Millisecond
-	handler.LinkRecoveryTimeout = 200 * time.Millisecond
+	handler.LinkRecoveryTimeout = 500 * time.Millisecond
 
 	if _, err := NewClient(handler).ReadHoldingRegisters(context.Background(), 0, 1); err == nil {
 		t.Fatal("expected an error, got nil")
 	}
 	handler.Close()
 
-	if codes := stop(); len(codes) < 2 {
+	if codes := observed(); len(codes) != 2 {
 		t.Errorf("link recovery should have reissued the read, got %d attempts: %v", len(codes), codes)
 	}
 }
@@ -584,7 +590,9 @@ func TestIsRepeatable(t *testing.T) {
 		{"read coils", adu(FuncCodeReadCoils), true},
 		{"read discrete inputs", adu(FuncCodeReadDiscreteInputs), true},
 		{"read FIFO queue", adu(FuncCodeReadFIFOQueue), true},
-		{"read device identification", adu(FuncCodeReadDeviceIdentification), true},
+		// Encapsulated Interface Transport: only MEI type 14 is a read, MEI type 13
+		// can write, and the MEI byte is past what the predicate inspects.
+		{"read device identification", adu(FuncCodeReadDeviceIdentification), false},
 		{"write single register", adu(FuncCodeWriteSingleRegister), false},
 		{"write multiple registers", adu(FuncCodeWriteMultipleRegisters), false},
 		{"write single coil", adu(FuncCodeWriteSingleCoil), false},

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -293,6 +293,33 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 	}
 }
 
+// TestTCPCloseResetsLateResponseWindow verifies that closing the connection
+// collapses the late-response window. A transaction ID that was in flight on the
+// old socket must not be accepted as a late response afterwards: draining it
+// would leave the read to time out cleanly, which keeps the very connection the
+// close was meant to discard.
+func TestTCPCloseResetsLateResponseWindow(t *testing.T) {
+	handler := NewTCPClientHandler("irrelevant")
+	tr := &handler.tcpTransporter
+
+	tr.lastSuccessfulTransactionID = 10
+	tr.lastAttemptedTransactionID = 20
+	if !tr.isLateResponse(15) {
+		t.Fatal("precondition: 15 should be inside the window before the close")
+	}
+
+	tr.mu.Lock()
+	err := tr.close()
+	tr.mu.Unlock()
+	if err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if tr.isLateResponse(15) {
+		t.Error("no transaction ID may be treated as late after a close: nothing can still be in flight on a connection that is gone")
+	}
+}
+
 // TestTCPMidFrameTimeoutClosesConnection verifies that a read timeout which hit
 // after part of a response header had already been consumed closes the
 // connection. Keeping such a connection leaves the remainder of that frame

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -19,6 +19,7 @@ import (
 	"math/big"
 	"net"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 )
@@ -289,6 +290,135 @@ func TestTCPTransactionMismatchRetry(t *testing.T) {
 	}
 	if !bytes.Equal(resp, data) {
 		t.Fatalf("got wrong response: got %q wanted %q", resp, data)
+	}
+}
+
+// TestTCPMidFrameTimeoutClosesConnection verifies that a read timeout which hit
+// after part of a response header had already been consumed closes the
+// connection. Keeping such a connection leaves the remainder of that frame
+// queued, so the next Send would parse those leftover bytes as a header and the
+// stream would stay misaligned for good.
+func TestTCPMidFrameTimeoutClosesConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Write a partial header - 3 of tcpHeaderSize bytes - and then stall, so
+		// that the client's ReadFull consumes those bytes and then times out.
+		if _, err := conn.Write([]byte{0x00, 0x01, 0x00}); err != nil {
+			t.Error(err)
+			return
+		}
+		// keep the connection open until the main routine is finished
+		<-done
+	}()
+
+	handler := NewTCPClientHandler(ln.Addr().String())
+	handler.Timeout = 200 * time.Millisecond
+	tr := &handler.tcpTransporter
+
+	getConn := func() net.Conn {
+		tr.mu.Lock()
+		defer tr.mu.Unlock()
+		return tr.conn
+	}
+
+	_, err = NewClient(handler).ReadInputRegisters(context.Background(), 0, 1)
+	if !errors.Is(err, ErrStreamDesynced) {
+		t.Fatalf("expected error wrapping %v, got %q", ErrStreamDesynced, err)
+	}
+	if conn := getConn(); conn != nil {
+		t.Fatalf("conn must be nil after a mid-frame timeout, got %v", conn)
+	}
+}
+
+// TestTCPNeverResendsSameTransactionID verifies that the transporter never writes
+// the same ADU to the wire twice. A response that cannot be attributed to the
+// request must close the connection and report, rather than re-sending: an
+// identical frame delivers a duplicate request, and for a write function code the
+// device would execute the command twice.
+func TestTCPNeverResendsSameTransactionID(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// ADU size of a ReadInputRegisters request: header, function code, address
+	// and quantity.
+	const requestLen = tcpHeaderSize + 1 + 2 + 2
+
+	var (
+		mu       sync.Mutex
+		observed []uint16
+	)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		packager := &tcpPackager{SlaveID: 0}
+		for {
+			req := make([]byte, requestLen)
+			if _, err := io.ReadFull(conn, req); err != nil {
+				return // client closed the connection
+			}
+			mu.Lock()
+			observed = append(observed, binary.BigEndian.Uint16(req))
+			isFirst := len(observed) == 1
+			mu.Unlock()
+
+			resp, err := packager.Encode(&ProtocolDataUnit{
+				FunctionCode: FuncCodeReadInputRegisters,
+				Data:         []byte{0x02, 0xCA, 0xFE},
+			})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if isFirst {
+				// Answer with a transaction ID that is neither the requested one nor a
+				// plausible late response, so that verify fails outside the leniency
+				// window. This is where the transporter used to re-write the identical
+				// request onto the wire.
+				binary.BigEndian.PutUint16(resp, 0xBEEF)
+			} else {
+				binary.BigEndian.PutUint16(resp, binary.BigEndian.Uint16(req))
+			}
+			if _, err := conn.Write(resp); err != nil {
+				return
+			}
+		}
+	}()
+
+	handler := NewTCPClientHandler(ln.Addr().String())
+	handler.Timeout = time.Second
+	// Non-zero, so that the leniency window is evaluated at all.
+	handler.ProtocolRecoveryTimeout = 500 * time.Millisecond
+
+	_, err = NewClient(handler).ReadInputRegisters(context.Background(), 0, 1)
+	if !errors.Is(err, ErrStreamDesynced) {
+		t.Fatalf("expected error wrapping %v, got %q", ErrStreamDesynced, err)
+	}
+	handler.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	// A resend would show up as a second entry carrying the same transaction ID.
+	if len(observed) != 1 {
+		t.Fatalf("expected exactly 1 request on the wire, got %d: %v", len(observed), observed)
 	}
 }
 

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -369,12 +369,14 @@ func TestTCPMidFrameTimeoutClosesConnection(t *testing.T) {
 	}
 }
 
-// TestTCPNeverResendsSameTransactionID verifies that the transporter never writes
-// the same ADU to the wire twice. A response that cannot be attributed to the
-// request must close the connection and report, rather than re-sending: an
-// identical frame delivers a duplicate request, and for a write function code the
-// device would execute the command twice.
-func TestTCPNeverResendsSameTransactionID(t *testing.T) {
+// TestTCPNoResendOnUnattributableResponse verifies that a response which cannot
+// be attributed to the request closes the connection and is reported, rather than
+// re-sending: an identical frame delivers a duplicate request, and for a write
+// function code the device would execute the command twice.
+//
+// Scoped to the protocol-desync path. Link recovery still reissues a *read* after
+// reconnecting - see TestTCPLinkRecovery* below.
+func TestTCPNoResendOnUnattributableResponse(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -446,6 +448,133 @@ func TestTCPNeverResendsSameTransactionID(t *testing.T) {
 	// A resend would show up as a second entry carrying the same transaction ID.
 	if len(observed) != 1 {
 		t.Fatalf("expected exactly 1 request on the wire, got %d: %v", len(observed), observed)
+	}
+}
+
+// countRequestsUntilClientGivesUp accepts connections on ln and records the
+// function code of every request it reads, dropping each connection immediately
+// without answering so that the client's link recovery engages. It returns a stop
+// function that waits for the server goroutine and yields the recorded codes.
+func countRequestsUntilClientGivesUp(t *testing.T, ln net.Listener) func() []byte {
+	t.Helper()
+
+	var (
+		mu    sync.Mutex
+		codes []byte
+		wg    sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			// header + function code is enough to identify the request
+			req := make([]byte, tcpHeaderSize+1)
+			if _, err := io.ReadFull(conn, req); err == nil {
+				mu.Lock()
+				codes = append(codes, req[tcpHeaderSize])
+				mu.Unlock()
+			}
+			conn.Close() // drop without answering
+		}
+	}()
+
+	return func() []byte {
+		ln.Close()
+		wg.Wait()
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]byte{}, codes...)
+	}
+}
+
+// TestTCPLinkRecoveryDoesNotReissueWrites verifies that a write is not reissued
+// after the remote side drops the connection without answering. The device may
+// have executed it already, and link recovery would repeat it verbatim on every
+// attempt until the recovery budget expires.
+func TestTCPLinkRecoveryDoesNotReissueWrites(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := countRequestsUntilClientGivesUp(t, ln)
+
+	handler := NewTCPClientHandler(ln.Addr().String())
+	handler.Timeout = 500 * time.Millisecond
+	handler.LinkRecoveryTimeout = 500 * time.Millisecond
+
+	if _, err := NewClient(handler).WriteSingleRegister(context.Background(), 0, 1); err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	handler.Close()
+
+	if codes := stop(); len(codes) != 1 {
+		t.Errorf("a write must reach the device at most once, got %d attempts: %v", len(codes), codes)
+	}
+}
+
+// TestTCPLinkRecoveryReissuesReads is the counterpart: gating link recovery on
+// the function code must not disable it for reads, where reissuing the request
+// has no effect on the device.
+func TestTCPLinkRecoveryReissuesReads(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := countRequestsUntilClientGivesUp(t, ln)
+
+	handler := NewTCPClientHandler(ln.Addr().String())
+	handler.Timeout = 500 * time.Millisecond
+	handler.LinkRecoveryTimeout = 200 * time.Millisecond
+
+	if _, err := NewClient(handler).ReadHoldingRegisters(context.Background(), 0, 1); err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	handler.Close()
+
+	if codes := stop(); len(codes) < 2 {
+		t.Errorf("link recovery should have reissued the read, got %d attempts: %v", len(codes), codes)
+	}
+}
+
+func TestIsRepeatable(t *testing.T) {
+	adu := func(fc byte) []byte {
+		return []byte{0, 1, 0, 0, 0, 2, 0, fc}
+	}
+
+	cases := []struct {
+		name string
+		adu  []byte
+		want bool
+	}{
+		{"read holding registers", adu(FuncCodeReadHoldingRegisters), true},
+		{"read input registers", adu(FuncCodeReadInputRegisters), true},
+		{"read coils", adu(FuncCodeReadCoils), true},
+		{"read discrete inputs", adu(FuncCodeReadDiscreteInputs), true},
+		{"read FIFO queue", adu(FuncCodeReadFIFOQueue), true},
+		{"read device identification", adu(FuncCodeReadDeviceIdentification), true},
+		{"write single register", adu(FuncCodeWriteSingleRegister), false},
+		{"write multiple registers", adu(FuncCodeWriteMultipleRegisters), false},
+		{"write single coil", adu(FuncCodeWriteSingleCoil), false},
+		{"write multiple coils", adu(FuncCodeWriteMultipleCoils), false},
+		{"mask write register", adu(FuncCodeMaskWriteRegister), false},
+		// Reads as well as writes, so it must not be repeated.
+		{"read/write multiple registers", adu(FuncCodeReadWriteMultipleRegisters), false},
+		// Unknown vendor code: assume it writes.
+		{"vendor specific", adu(0x41), false},
+		// Malformed: no function code to inspect.
+		{"truncated adu", []byte{0, 1, 0, 0, 0, 2, 0}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRepeatable(tc.adu); got != tc.want {
+				t.Errorf("isRepeatable = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/tcpclient_test.go
+++ b/tcpclient_test.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"net"
 	"slices"
@@ -470,14 +469,15 @@ func TestTCPNoResendOnUnattributableResponse(t *testing.T) {
 	}
 }
 
-// countRequests accepts connections on ln and records the function code of every
-// request it reads. The first dropAfter connections are closed without answering,
-// so the client's link recovery engages; any connection after that is answered so
-// the client stops instead of spinning until its recovery budget expires.
+// serveRequests accepts connections on ln and records the function code of every
+// request it reads. For each connection it asks reply what to write back, given
+// the zero-based connection index and the request bytes; returning nil closes
+// without answering, which is what makes the client's link recovery engage. Every
+// connection is closed after the reply, so each recovery attempt gets a fresh one.
 //
 // It registers its own cleanup, so a t.Fatal in the caller cannot leak the
 // listener or the accept goroutine, and returns the codes observed so far.
-func countRequests(t *testing.T, ln net.Listener, dropAfter int) func() []byte {
+func serveRequests(t *testing.T, ln net.Listener, reply func(i int, req []byte) []byte) func() []byte {
 	t.Helper()
 
 	var (
@@ -488,7 +488,7 @@ func countRequests(t *testing.T, ln net.Listener, dropAfter int) func() []byte {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
+		for i := 0; ; i++ {
 			conn, err := ln.Accept()
 			if err != nil {
 				return // listener closed
@@ -498,12 +498,8 @@ func countRequests(t *testing.T, ln net.Listener, dropAfter int) func() []byte {
 			if _, err := io.ReadFull(conn, req); err == nil {
 				mu.Lock()
 				codes = append(codes, req[tcpHeaderSize])
-				answer := len(codes) > dropAfter
 				mu.Unlock()
-				if answer {
-					// Any well-formed frame will do: the client only has to stop
-					// reconnecting. An exception response is the shortest one.
-					resp := []byte{req[0], req[1], 0, 0, 0, 3, req[6], req[tcpHeaderSize] | 0x80, ExceptionCodeIllegalDataAddress}
+				if resp := reply(i, req); resp != nil {
 					_, _ = conn.Write(resp)
 				}
 			}
@@ -523,6 +519,20 @@ func countRequests(t *testing.T, ln net.Listener, dropAfter int) func() []byte {
 	}
 }
 
+// exceptionReply is the shortest well-formed response to req. Tests use it when
+// they only need the client to stop reconnecting; the exception itself is not
+// what is under test.
+func exceptionReply(req []byte) []byte {
+	return []byte{req[0], req[1], 0, 0, 0, 3, req[6], req[tcpHeaderSize] | 0x80, ExceptionCodeIllegalDataAddress}
+}
+
+// truncatedReply is a valid MBAP header announcing a four-byte body, with no body
+// following it. The client reads the header, then hits EOF part-way through the
+// frame - which means the socket is gone, not that the stream is misaligned.
+func truncatedReply(req []byte) []byte {
+	return []byte{req[0], req[1], 0, 0, 0, 5, req[6]}
+}
+
 // TestTCPLinkRecoveryDoesNotReissueWrites verifies that a write is not reissued
 // after the remote side drops the connection without answering. The device may
 // have executed it already, and link recovery would repeat it verbatim on every
@@ -532,7 +542,8 @@ func TestTCPLinkRecoveryDoesNotReissueWrites(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	observed := countRequests(t, ln, math.MaxInt)
+	// Never answered, so link recovery keeps getting a dead connection.
+	observed := serveRequests(t, ln, func(int, []byte) []byte { return nil })
 
 	handler := NewTCPClientHandler(ln.Addr().String())
 	handler.Timeout = 500 * time.Millisecond
@@ -559,7 +570,12 @@ func TestTCPLinkRecoveryReissuesReads(t *testing.T) {
 	// Drop only the first connection: the reissued read is then answered, so the
 	// client stops after two attempts instead of churning thousands of sockets
 	// until the recovery budget expires.
-	observed := countRequests(t, ln, 1)
+	observed := serveRequests(t, ln, func(i int, req []byte) []byte {
+		if i == 0 {
+			return nil
+		}
+		return exceptionReply(req)
+	})
 
 	handler := NewTCPClientHandler(ln.Addr().String())
 	handler.Timeout = 500 * time.Millisecond
@@ -572,6 +588,65 @@ func TestTCPLinkRecoveryReissuesReads(t *testing.T) {
 
 	if codes := observed(); len(codes) != 2 {
 		t.Errorf("link recovery should have reissued the read, got %d attempts: %v", len(codes), codes)
+	}
+}
+
+// TestTCPLinkRecoveryReissuesReadAfterTruncatedResponse covers the same situation
+// as TestTCPLinkRecoveryReissuesReads, but hit one branch later: the header was
+// consumed and the socket then went away part-way through the body. Nothing of the
+// frame is left queued, so this is a dead connection rather than a misaligned
+// stream, and a read must be reissued on a fresh one just as it is when the
+// header read fails.
+func TestTCPLinkRecoveryReissuesReadAfterTruncatedResponse(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Truncate the first response, answer the reissued one.
+	observed := serveRequests(t, ln, func(i int, req []byte) []byte {
+		if i == 0 {
+			return truncatedReply(req)
+		}
+		return exceptionReply(req)
+	})
+
+	handler := NewTCPClientHandler(ln.Addr().String())
+	handler.Timeout = 500 * time.Millisecond
+	handler.LinkRecoveryTimeout = 500 * time.Millisecond
+
+	if _, err := NewClient(handler).ReadHoldingRegisters(context.Background(), 0, 1); err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	handler.Close()
+
+	if codes := observed(); len(codes) != 2 {
+		t.Errorf("a read should have been reissued after the truncated response, got %d attempts: %v", len(codes), codes)
+	}
+}
+
+// TestTCPLinkRecoveryDoesNotReissueWriteAfterTruncatedResponse is the write half:
+// the device answered far enough to prove it processed the request, so reissuing
+// would execute the command twice.
+func TestTCPLinkRecoveryDoesNotReissueWriteAfterTruncatedResponse(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed := serveRequests(t, ln, func(_ int, req []byte) []byte {
+		return truncatedReply(req)
+	})
+
+	handler := NewTCPClientHandler(ln.Addr().String())
+	handler.Timeout = 500 * time.Millisecond
+	handler.LinkRecoveryTimeout = 500 * time.Millisecond
+
+	if _, err := NewClient(handler).WriteSingleRegister(context.Background(), 0, 1); err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	handler.Close()
+
+	if codes := observed(); len(codes) != 1 {
+		t.Errorf("a write must reach the device at most once, got %d attempts: %v", len(codes), codes)
 	}
 }
 


### PR DESCRIPTION
## The bug

The TCP transporter could put the **same Modbus frame, including the same transaction ID, on the wire twice**. For a write function code that means the device executes the command twice.

This surfaced on a Huawei Sun2000 + EMMA installation — the first setup we know of that writes to **two different slave IDs over one TCP connection**. Control worked for a while, then the device began rejecting every write with exception 4 (server device failure). A packet capture showed the duplicated frame.

Two defects compose into it:

**1. A read timeout kept the connection open unconditionally** (`Send`, `readResultDone` branch). But `io.ReadFull` for the header, and the body read in `processResponse`, can fail *after* consuming part of a frame. Retaining that connection leaves the rest of the frame queued, so the next `Send` parses those leftover bytes as a header — and the stream stays misaligned from then on. The existing comment assumed a late response could always be drained via transaction-ID matching, which only holds while frame boundaries are intact.

**2. `readResultRetry` re-wrote the identical `aduRequest` buffer.** It was reached in exactly the situations where the stream was already misaligned (`ErrTCPHeaderLength`) or where a response could not be attributed to the request. So the resend both duplicated the request and compounded the desync.

The leniency window could not break out of it either: a duplicate of an already-consumed response has `got == lastSuccessfulTransactionID`, which fails the window check and falls through to the resend. Worse, the resend *appeared to work* — it consumed the stray frame, re-asked, and returned **success** to the caller — while leaving a second answer to the same transaction ID in flight. That answer fails the window check on the next request, which resends again. This is why the field symptom was permanent rather than intermittent: the recovery mechanism was manufacturing the condition it appeared to fix.

## Evidence

Both defects, reproduced against `master` before the fix:

```
conn must be nil after a mid-frame timeout, got &{{0x40000dc480}}

call returned err=<nil>
expected exactly 1 request on the wire, got 2: [1 1]
```

Transaction ID `1` written twice — and the caller got `err=<nil>`, so a duplicate write was reported to the application as a success.

## The change

- Add `ErrStreamDesynced` and mark the mid-frame cases with it: a header read that consumed `n > 0` bytes, and every `processResponse` failure (the header was already fully consumed there, so it is mid-frame by construction).
- `Send` now keeps the connection only on a **clean** timeout — nothing consumed, stream still frame-aligned. A mid-frame timeout closes.
- Remove `readResultRetry`. The transporter cannot safely retry: it does not know whether the request was a write, and it cannot re-encode with a fresh transaction ID because it does not own the packager. That decision belongs to the caller, and reissuing there encodes a new transaction ID.
- Extract the out-of-window predicate into `isLateResponse` — the wraparound logic is preserved verbatim, just named and readable.

### Deliberately unchanged

- **The in-window "late response" drain.** Discarding a stale response from an *intact* stream without resending is correct, and it is the one case where the connection really is healthy. `TestTCPTransactionMismatchRetry` covers this and still passes untouched.
- **`readResultCloseRetry`** for link recovery, where the remote closed before sending anything at all — there the stream is empty rather than misaligned. Note it does reissue the request after reconnecting, which is a narrower instance of the same class of problem; left alone here to keep link-recovery semantics (including the recently added serial path) untouched.

## Tests

Two additions to `tcpclient_test.go`, both failing before this change and passing after:

- `TestTCPMidFrameTimeoutClosesConnection` — a server that writes a partial header and stalls must leave `conn == nil`.
- `TestTCPNeverResendsSameTransactionID` — a server answering with an unattributable transaction ID must never see the same request twice on the wire.

`make ci_test` passes in full: TCP, RTU and ASCII suites against diagslave and PTYs. The `TCP` filter picks up both new tests.

## Conformance

Checked against *MODBUS Messaging on TCP/IP Implementation Guide V1.0b*.

Two independent rules are at work here, and they are easy to conflate:

**Protocol legality.** §4.4.1.2: "at a time, **on a TCP connection**, this identifier must be unique." Re-writing the same ADU on the *same* connection while the original transaction is still pending creates two live transactions carrying one identifier, so the old behaviour was a protocol violation and removing it is a conformance fix. Note the scoping: reissuing a request on a freshly dialled connection does **not** violate this, because the old socket — and with it the pending transaction — is gone.

**Idempotency.** Whether executing a request twice changes the device. The spec says nothing about this; it is a property of physical equipment. Reads are free to repeat, writes are not.

Each rule is applied uniformly to reads and writes:

| Path | Governed by | Before | After |
|---|---|---|---|
| Same-connection resend on protocol desync | §4.4.1.2 — illegal | resent the identical ADU, sometimes returning success | closes and reports `ErrStreamDesynced` — reads *and* writes |
| Fresh-connection reissue on link recovery | idempotency — spec-legal either way | reissued any request | reads reissued as before, writes reported |

So the function-code gate is **not** a spec requirement. It rests on idempotency alone. (RTU has no transaction identifier at all, which is why the same hazard on the serial path — see below — is purely an idempotency problem.)

Supporting the layering: Figure 11 routes a retry back through *Build a MODBUS Request* — a fresh transaction, not a byte-identical replay — and §4.4.1.4 warns that retrying faster than the maximum reasonable response time risks "excessive congestion at the target device", which "should always be avoided".

One conscious deviation: §4.4.1.3 says a response whose transaction identifier matches no pending transaction "must be discarded", i.e. discard it and keep reading, without implicating the connection. This change closes instead. That is stricter than the standard; it is deliberate, because the same branch is also reachable when the stream really is misaligned (the tail of an earlier frame can parse as a plausible header) and the two cases cannot be distinguished from the outside.

## Behaviour changes for consumers

The API is additive — `ErrStreamDesynced` is new, and `readResultRetry` and `flush` were unexported — so nothing fails to compile. Everything below is behavioural.

**Writes.** Every path that reissued a write is now closed, on both rules above. A caller that previously saw a write succeed after a link hiccup will now get an error. This is not optional: any way of preserving it re-executes a command on live equipment, which is the defect this PR exists to fix.

**Reads**, versus the base commit:

| Situation | Before | After | |
|---|---|---|---|
| Header read fails with EOF/ECONNRESET | reconnect and reissue | unchanged | |
| Header read times out mid-frame | connection kept (desynchronised), error returned | connection closed, error returned | caller sees an error either way |
| `processResponse` hits EOF/ECONNRESET mid-body | reconnect and reissue | unchanged | |
| `processResponse` reports an implausible length | same-connection resend, could succeed | hard error | **regression** |
| `verify` reports an out-of-window transaction ID | same-connection resend, could succeed | hard error | intended — see *The bug* |

The out-of-window case is the loop that made the field symptom permanent, so failing there is the point. The implausible-length case is the one remaining collateral change: there the stream really is misaligned, so the old same-connection resend was unsafe — it could be routed through link recovery instead (reconnect, then reissue if repeatable), but that is a broader claim about reconnecting being the right answer to a device emitting garbage, so it is left failing. Say so in review if you disagree.

Everything else on the read path is unchanged, and the rule is uniform: **socket gone with nothing queued** means link recovery may redial and reissue a repeatable request; anything else means desync, close and report.

Also worth knowing: this fixes the TCP transport only. `rtuclient.go` and `asciiclient.go` still reissue writes verbatim after reconnecting — same hazard, tracked in #135 (the repeatability policy lives in `funcCodeRepeatable` in `modbus.go` precisely so that fix is small). And link recovery has no retry interval at all: #134.

One property this PR does not change, worth stating so it is not mistaken for a guarantee: a write that fails *after* being sent is inherently in doubt. The transport no longer reissues it, but it also cannot tell the caller whether the device acted on it, so an upper layer with a generic retry may still send it a second time — once, with a fresh transaction ID, rather than the unbounded identical-ADU storm this PR removes. Most register writes are idempotent in effect, so this is usually harmless; for command-style registers it is a decision for the caller.

## Notes for reviewers

- `ErrStreamDesynced` is the only added API surface. It is what lets a caller tell a desync apart from a plain timeout and retry deliberately — the protocol error types stay unexported. Happy to export those separately if useful.
- On how much the read regressions above actually bite: `LinkRecoveryTimeout` is measured from the start of `Send` and is typically far shorter than a device's response time (in our fleet the median read is ~158 ms against a 53 ms budget, so ~85% of reads could never reach that recovery path anyway). Callers with their own reconnect-and-retry are unaffected. And removing the silent in-`Send` reconnect is itself an improvement: a connection replaced invisibly skips any post-connect initialisation the caller performs.

Refs: https://grid-x.atlassian.net/browse/INTE-6086
Related: #56 (same-connection multi-slave-ID use, which is how we hit this)




